### PR TITLE
Do not publish images in the head-update job

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,19 +5,6 @@ gardener-extension-registry-cache:
     traits:
       version:
         preprocess: 'inject-commit-hash'
-      publish:
-        oci-builder: 'docker-buildx'
-        dockerimages:
-          gardener-extension-registry-cache:
-            registry: 'gcr-readwrite'
-            image: 'eu.gcr.io/gardener-project/gardener/extensions/registry-cache'
-            dockerfile: 'Dockerfile'
-            target: registry-cache
-          gardener-extension-registry-cache-admission:
-            registry: 'gcr-readwrite'
-            image: 'eu.gcr.io/gardener-project/gardener/extensions/registry-cache-admission'
-            dockerfile: 'Dockerfile'
-            target: registry-cache-admission
   jobs:
     head-update:
       traits:
@@ -47,6 +34,14 @@ gardener-extension-registry-cache:
           oci-builder: 'docker-buildx'
           dockerimages:
             gardener-extension-registry-cache:
+              registry: 'gcr-readwrite'
+              image: 'eu.gcr.io/gardener-project/gardener/extensions/registry-cache'
+              dockerfile: 'Dockerfile'
+              target: registry-cache
               tag_as_latest: true
             gardener-extension-registry-cache-admission:
+              registry: 'gcr-readwrite'
+              image: 'eu.gcr.io/gardener-project/gardener/extensions/registry-cache-admission'
+              dockerfile: 'Dockerfile'
+              target: registry-cache-admission
               tag_as_latest: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # [Gardener Extension for Registry Cache](https://gardener.cloud)
+
+[![CI Build status](https://concourse.ci.gardener.cloud/api/v1/teams/gardener/pipelines/gardener-extension-registry-cache-main/jobs/main-head-update-job/badge)](https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-extension-registry-cache-main/jobs/main-head-update-job)
+
 Gardener extension controller which deploys pull-through caches for container registries.
 
 ## Learn more!


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
Currently the head-update job is building and pushing container images (see https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-extension-registry-cache-main/jobs/main-head-update-job/builds/1). This task is already tackled by prow (see https://prow.gardener.cloud/view/gs/gardener-prow/logs/post-gardener-extension-registry-cache-build-images/1615047981784895488). Hence, we don't want the concourse head-update job to publish container images (similar to the head-update job of gardener).

**Which issue(s) this PR fixes**:
See above.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
