### PR TITLE
Switched from DockerHub to Gardener GCR

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -1,9 +1,9 @@
 images:
 - name: registry
   sourceRepository: github.com/distribution/distribution
-  repository: registry
+  repository: eu.gcr.io/gardener-project/3rd/registry
   tag: "2.8.1"
 - name: cri-config-ensurer
   sourceRepository: github.com/tianon/docker-bash
-  repository: bash
+  repository: eu.gcr.io/gardener-project/3rd/bash
   tag: "5.2.0-alpine3.15"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR is needed to support IPv6 single stack and avoid DockerHub pull limits as it uses copied images from Gardener GCR instead.
Part of https://github.com/gardener/ci-infra/issues/619

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Switched images from DockerHub to copies in Gardener GCR
```
