### PR TITLE
Fix cri-config-ensurer and registry images

### DIFF
--- a/pkg/controller/criensurerdeployer.go
+++ b/pkg/controller/criensurerdeployer.go
@@ -131,7 +131,7 @@ func (c *criEnsurer) Ensure() ([]client.Object, error) {
 					Containers: []corev1.Container{
 						{
 							Name:  criEnsurerName,
-							Image: c.CRIEnsurerImage.Repository,
+							Image: c.CRIEnsurerImage.String(),
 							Command: []string{
 								"bash",
 								"-c",

--- a/pkg/controller/registrydeployer.go
+++ b/pkg/controller/registrydeployer.go
@@ -109,7 +109,7 @@ func (c *registryCache) Ensure() ([]client.Object, error) {
 						Containers: []v1.Container{
 							{
 								Name:            registryCacheInternalName,
-								Image:           c.RegistryImage.Repository,
+								Image:           c.RegistryImage.String(),
 								ImagePullPolicy: v1.PullIfNotPresent,
 								Ports: []v1.ContainerPort{
 									{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind regression
/kind bug

**What this PR does / why we need it**:
Currently the cri-config-ensurer has the following code for the image:
https://github.com/gardener/gardener-extension-registry-cache/blob/0ef3e17b22d78bdd467af2b6392b00922b483c7a/pkg/controller/criensurerdeployer.go#L134

Note that it uses only the repository and ignores any tag.

This results in the Pod to be created such as:
```yaml
  containers:
  - name: name: cri-config-ensurer
    image: eu.gcr.io/gardener-project/3rd/bash
```

After https://github.com/gardener/gardener-extension-registry-cache/pull/17, the repo is switched to `eu.gcr.io/gardener-project/3rd/bash` and the latest tag does no longer exists. Hence, currently the cri-config-ensurer cannot be pulled at all:
```
% k -n registry-cache get po
NAME                       READY   STATUS             RESTARTS   AGE
cri-config-ensurer-xs7l6   0/1     ImagePullBackOff   0          43m
``` 

```
  Warning  Failed     13m (x3 over 14m)     kubelet            Failed to pull image "eu.gcr.io/gardener-project/3rd/bash": rpc error: code = NotFound desc = failed to pull and unpack image "eu.gcr.io/gardener-project/3rd/bash:latest": failed to resolve reference "eu.gcr.io/gardener-project/3rd/bash:latest": eu.gcr.io/gardener-project/3rd/bash:latest: not found
```

The same applies for the registry image:
```
  Warning  Failed            6s                   kubelet            Failed to pull image "eu.gcr.io/gardener-project/3rd/registry": rpc error: code = NotFound desc = failed to pull and unpack image "eu.gcr.io/gardener-project/3rd/registry:latest": failed to resolve reference "eu.gcr.io/gardener-project/3rd/registry:latest": eu.gcr.io/gardener-project/3rd/registry:latest: not found
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
