### PR TITLE
Add `hack/tools/bin/.gitkeep`. Fix `make extension-up`. Deflake the e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ ci-e2e-kind:
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
 extension-up extension-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=extension-local
 
-extension-up: $(SKAFFOLD) $(HELM)
+extension-up: $(SKAFFOLD) $(KIND) $(HELM)
 	$(SKAFFOLD) run
 
 extension-dev: $(SKAFFOLD) $(HELM)
@@ -182,7 +182,7 @@ extension-down: $(SKAFFOLD) $(HELM)
 admission-up admission-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=admission-local
 admission-%: export SKAFFOLD_FILENAME = skaffold-admission.yaml
 
-admission-up: $(SKAFFOLD) $(HELM)
+admission-up: $(SKAFFOLD) $(KIND) $(HELM)
 	$(SKAFFOLD) run
 
 admission-dev: $(SKAFFOLD) $(HELM)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
Currently `make ci-e2e-kind` on a freshly cloned repo fails with:
```
touch: cannot touch 'hack/tools/bin/.version_skaffold_v2.2.0': No such file or directory
```

This PR is similar to https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/8.

This will hopefully fix the failing e2e-kind prow job.

**Which issue(s) this PR fixes**:
See above.

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
