### PR TITLE
Add testmachinery integration tests

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,3 +13,7 @@ updates:
   directory: /
   schedule:
     interval: daily
+- package-ecosystem: docker
+  directory: /.test-defs
+  schedule:
+    interval: daily

--- a/.test-defs/TestSuiteRegistryCacheBetaSerial.yaml
+++ b/.test-defs/TestSuiteRegistryCacheBetaSerial.yaml
@@ -1,0 +1,25 @@
+apiVersion: testmachinery.sapcloud.io
+kind: TestDefinition
+metadata:
+  name: registry-cache-beta-serial-test-suite
+spec:
+  owner: gardener-oq@listserv.sap.com
+  description: registry-cache extension test suite that includes all serial beta tests
+
+  activeDeadlineSeconds: 7200
+  labels: ["shoot", "beta"]
+  behavior:
+  - serial
+
+  command: [bash, -c]
+  args:
+    - >-
+      go test -timeout=0 -mod=vendor ./test/testmachinery/shoot
+      --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color
+      -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
+      -project-namespace=$PROJECT_NAMESPACE
+      -shoot-name=$SHOOT_NAME
+      -ginkgo.focus="\[BETA\].*\[SERIAL\]"
+      -ginkgo.skip="\[DISRUPTIVE\]"
+
+  image: golang:1.21.1

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/test/framework"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha1"
+)
+
+const (
+	// Nginx1130ImageWithDigest corresponds to the nginx:1.13.0 image.
+	Nginx1130ImageWithDigest = "library/nginx@sha256:12d30ce421ad530494d588f87b2328ddc3cae666e77ea1ae5ac3a6661e52cde6"
+	// Nginx1140ImageWithDigest corresponds to the nginx:1.14.0 image.
+	Nginx1140ImageWithDigest = "library/nginx@sha256:8b600a4d029481cc5b459f1380b30ff6cb98e27544fc02370de836e397e34030"
+	// Nginx1150ImageWithDigest corresponds to the nginx:1.15.0 image.
+	Nginx1150ImageWithDigest = "library/nginx@sha256:62a095e5da5f977b9f830adaf64d604c614024bf239d21068e4ca826d0d629a4"
+)
+
+// AddRegistryCacheExtension adds registry-cache extension with the given upstream and size to to given Shoot.
+func AddRegistryCacheExtension(shoot *gardencorev1beta1.Shoot, upstream string, size *resource.Quantity) {
+	providerConfig := &v1alpha1.RegistryConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+			Kind:       "RegistryConfig",
+		},
+		Caches: []v1alpha1.RegistryCache{
+			{
+				Upstream: upstream,
+				Size:     size,
+			},
+		},
+	}
+	providerConfigJSON, err := json.Marshal(&providerConfig)
+	utilruntime.Must(err)
+
+	extension := gardencorev1beta1.Extension{
+		Type: "registry-cache",
+		ProviderConfig: &runtime.RawExtension{
+			Raw: providerConfigJSON,
+		},
+	}
+
+	shoot.Spec.Extensions = append(shoot.Spec.Extensions, extension)
+}
+
+// RemoveRegistryCacheExtension removes registry-caches extensions from given Shoot.
+func RemoveRegistryCacheExtension(shoot *gardencorev1beta1.Shoot) {
+	shoot.Spec.Extensions = slices.DeleteFunc(shoot.Spec.Extensions, func(extension gardencorev1beta1.Extension) bool {
+		return extension.Type == "registry-cache"
+	})
+}
+
+// VerifyRegistryCache verifies that a registry cache works as expected.
+//
+// The verification consists of the following steps:
+//  1. It deploys an nginx Pod with the given image.
+//  2. It waits until the Pod is running.
+//  3. It verifies that the image is present in the registry's scheduler-state.json file.
+//     This is a verification that the image pull happened via the registry cache (and the containerd didn't fall back to the upstream).
+func VerifyRegistryCache(parentCtx context.Context, log logr.Logger, shootClient kubernetes.Interface, upstream, nginxImageWithDigest string) {
+	By("Create nginx Pod")
+	ctx, cancel := context.WithTimeout(parentCtx, 5*time.Minute)
+	defer cancel()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "nginx-",
+			Namespace:    corev1.NamespaceDefault,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: nginxImageWithDigest,
+				},
+			},
+		},
+	}
+	ExpectWithOffset(1, shootClient.Client().Create(ctx, pod)).To(Succeed())
+
+	By("Wait until nginx Pod is running")
+	ExpectWithOffset(1, framework.WaitUntilPodIsRunning(ctx, log, pod.Name, pod.Namespace, shootClient)).To(Succeed())
+
+	By("Verify the registry cache pulled the nginx image")
+	ctx, cancel = context.WithTimeout(parentCtx, 2*time.Minute)
+	defer cancel()
+
+	selector := labels.SelectorFromSet(labels.Set(map[string]string{"upstream-host": upstream}))
+	var reader io.Reader
+	EventuallyWithOffset(1, ctx, func(g Gomega) (err error) {
+		reader, err = framework.PodExecByLabel(ctx, selector, "registry-cache", "cat /var/lib/registry/scheduler-state.json", metav1.NamespaceSystem, shootClient)
+		return err
+	}).WithPolling(10*time.Second).Should(Succeed(), "Expected to successfully cat registry's scheduler-state.json file")
+
+	schedulerStateFileContent, err := io.ReadAll(reader)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	schedulerStateMap := map[string]interface{}{}
+	ExpectWithOffset(1, json.Unmarshal(schedulerStateFileContent, &schedulerStateMap)).To(Succeed())
+	ExpectWithOffset(1, schedulerStateMap).To(HaveKey(nginxImageWithDigest), fmt.Sprintf("Expected to find image %s in the registry's scheduler-state.json file", nginxImageWithDigest))
+
+	By("Delete nginx Pod")
+	timeout := 5 * time.Minute
+	ctx, cancel = context.WithTimeout(parentCtx, timeout)
+	defer cancel()
+	ExpectWithOffset(1, framework.DeleteAndWaitForResource(ctx, shootClient, pod, timeout)).To(Succeed())
+}

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -15,35 +15,17 @@
 package e2e_test
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 	"os"
-	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/test/framework"
-	"github.com/go-logr/logr"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/pointer"
-
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha1"
 )
 
 const (
 	projectNamespace = "garden-local"
-	// nginxImageWithDigest corresponds to the nginx:1.13.0 image.
-	nginxImageWithDigest = "library/nginx@sha256:12d30ce421ad530494d588f87b2328ddc3cae666e77ea1ae5ac3a6661e52cde6"
 )
 
 func defaultShootCreationFramework() *framework.ShootCreationFramework {
@@ -102,69 +84,4 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 			},
 		},
 	}
-}
-
-func registryCacheExtension(upstream string, size *resource.Quantity) gardencorev1beta1.Extension {
-	providerConfig := &v1alpha1.RegistryConfig{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1alpha1.SchemeGroupVersion.String(),
-			Kind:       "RegistryConfig",
-		},
-		Caches: []v1alpha1.RegistryCache{
-			{
-				Upstream: upstream,
-				Size:     size,
-			},
-		},
-	}
-	providerConfigJSON, err := json.Marshal(&providerConfig)
-	utilruntime.Must(err)
-
-	extension := gardencorev1beta1.Extension{
-		Type: "registry-cache",
-		ProviderConfig: &runtime.RawExtension{
-			Raw: providerConfigJSON,
-		},
-	}
-
-	return extension
-}
-
-func verifyRegistryCache(parentCtx context.Context, log logr.Logger, shootClient kubernetes.Interface, upstream, nginxImageWithDigest string) {
-	By("Create nginx Pod")
-	ctx, cancel := context.WithTimeout(parentCtx, 5*time.Minute)
-	defer cancel()
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "nginx",
-			Namespace: corev1.NamespaceDefault,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  "nginx",
-					Image: nginxImageWithDigest,
-				},
-			},
-		},
-	}
-	ExpectWithOffset(1, shootClient.Client().Create(ctx, pod)).To(Succeed())
-	ExpectWithOffset(1, framework.WaitUntilPodIsRunning(ctx, log, pod.Name, pod.Namespace, shootClient)).To(Succeed())
-
-	By("Verify the registry cache pulled the nginx image")
-	ctx, cancel = context.WithTimeout(parentCtx, 2*time.Minute)
-	defer cancel()
-
-	selector := labels.SelectorFromSet(labels.Set(map[string]string{"upstream-host": upstream}))
-	var reader io.Reader
-	EventuallyWithOffset(1, ctx, func(g Gomega) (err error) {
-		reader, err = framework.PodExecByLabel(ctx, selector, "registry-cache", "cat /var/lib/registry/scheduler-state.json", metav1.NamespaceSystem, shootClient)
-		return err
-	}).WithPolling(10*time.Second).Should(Succeed(), "Expected to successfully cat registry's scheduler-state.json file")
-
-	schedulerStateFileContent, err := io.ReadAll(reader)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	schedulerStateMap := map[string]interface{}{}
-	ExpectWithOffset(1, json.Unmarshal(schedulerStateFileContent, &schedulerStateMap)).To(Succeed())
-	ExpectWithOffset(1, schedulerStateMap).To(HaveKey(nginxImageWithDigest), fmt.Sprintf("Expected to find image %s in the registry's scheduler-state.json file", nginxImageWithDigest))
 }

--- a/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
+++ b/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
@@ -23,6 +23,8 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener-extension-registry-cache/test/common"
 )
 
 var _ = Describe("Registry Cache Extension Tests", func() {
@@ -31,8 +33,7 @@ var _ = Describe("Registry Cache Extension Tests", func() {
 	f := defaultShootCreationFramework()
 	shoot := defaultShoot("e2e-hib")
 	size := resource.MustParse("2Gi")
-	extension := registryCacheExtension("docker.io", &size)
-	shoot.Spec.Extensions = []gardencorev1beta1.Extension{extension}
+	common.AddRegistryCacheExtension(shoot, "docker.io", &size)
 	f.Shoot = shoot
 
 	It("should create Shoot with registry-cache extension enabled, hibernate Shoot, reconcile Shoot, delete Shoot", func() {
@@ -43,7 +44,7 @@ var _ = Describe("Registry Cache Extension Tests", func() {
 		f.Verify()
 
 		By("Verify registry-cache works")
-		verifyRegistryCache(parentCtx, f.Logger, f.ShootFramework.ShootClient, "docker.io", nginxImageWithDigest)
+		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootFramework.ShootClient, "docker.io", common.Nginx1130ImageWithDigest)
 
 		By("Hibernate Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	"context"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/test/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener-extension-registry-cache/test/common"
+)
+
+const (
+	hibernationTestTimeout        = 50 * time.Minute
+	hibernationTestCleanupTimeout = 25 * time.Minute
+)
+
+var _ = Describe("Shoot registry cache testing", func() {
+	f := framework.NewShootFramework(nil)
+
+	f.Serial().Beta().CIt("should enable the extension, hibernate Shoot, reconcile Shoot, wake up Shoot, disable the extension", func(parentCtx context.Context) {
+		By("Enable the registry-cache extension")
+		ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
+		defer cancel()
+		Expect(f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
+			size := resource.MustParse("2Gi")
+			common.AddRegistryCacheExtension(shoot, "docker.io", &size)
+
+			return nil
+		})).To(Succeed())
+
+		By("Verify registry-cache works")
+		// We are using nginx:1.14.0 as nginx:1.13.0 is already used by the "should enable and disable the registry-cache extension" test.
+		// Hence, nginx:1.13.0 will be present in the Node.
+		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootClient, "docker.io", common.Nginx1140ImageWithDigest)
+
+		By("Hibernate Shoot")
+		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
+		defer cancel()
+		Expect(f.HibernateShoot(ctx)).To(Succeed())
+
+		By("Reconcile Shoot")
+		ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)
+		defer cancel()
+		Expect(f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
+			metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "reconcile")
+
+			return nil
+		})).To(Succeed())
+		Expect(f.WaitForShootToBeReconciled(ctx, f.Shoot)).To(Succeed())
+
+		By("Wake up Shoot")
+		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
+		defer cancel()
+		Expect(f.WakeUpShoot(ctx)).To(Succeed())
+
+		By("Verify registry-cache works after wake up")
+		// We are using nginx:1.15.0 as nginx:1.14.0 is already used above and already present in the Node and in the registry cache.
+		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootClient, "docker.io", common.Nginx1150ImageWithDigest)
+	}, hibernationTestTimeout, framework.WithCAfterTest(func(ctx context.Context) {
+		if v1beta1helper.HibernationIsEnabled(f.Shoot) {
+			By("Wake up Shoot")
+			Expect(f.WakeUpShoot(ctx)).To(Succeed())
+		}
+
+		By("Disable the registry-cache extension")
+		Expect(f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
+			common.RemoveRegistryCacheExtension(shoot)
+
+			return nil
+		})).To(Succeed())
+	}, hibernationTestCleanupTimeout))
+})

--- a/test/testmachinery/shoot/shoot_suite_test.go
+++ b/test/testmachinery/shoot/shoot_suite_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	"testing"
+
+	"github.com/gardener/gardener/test/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func init() {
+	framework.RegisterShootFrameworkFlags()
+}
+
+func TestShoot(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Shoot Suite")
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR adds a testmachinery integration tests for the extension.
Initially, I tried to add an envtest for the controller but during Extension reconciliation we are creating a Shoot client and fetching the registry-cache Service IP to update them in the Extension status. Hence, envtest does not seem to be suitable. We can of course try to fake/mock the interaction with the Shoot kube-apiserver but then it won't be a real integration test.
That's why I decided to add a testmachinery test instead of envtest.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/3

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
