### PR TITLE
Use `1.21.0` instead of `1.21` as module version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ endif
 #########################################
 
 TOOLS_DIR := hack/tools
+# goimports-reviser@v3.4.5 contains the fix for https://github.com/incu6us/goimports-reviser/issues/129.
+#
+# TODO(ialidzhikov): Drop this version overwrite when the registry-cache extension vendors https://github.com/gardener/gardener/pull/8450.
+GOIMPORTSREVISER_VERSION := v3.4.5
 include $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/tools.mk
 
 #########################################

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/gardener-extension-registry-cache
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
Currently dependabot fails with:
```
go: downloading go1.21 (linux/amd64)
go: download go1.21 for linux/amd64: toolchain not available
```

See https://github.com/dependabot/dependabot-core/issues/7895 and https://github.com/golang/go/issues/62278.
It seems that with go1.21 it is no longer possible to have `X.Y` as module version - see https://github.com/golang/go/issues/62278#issuecomment-1698829945.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
