### PR TITLE
Make the cache size field immutable

### DIFF
--- a/pkg/admission/validator/helper.go
+++ b/pkg/admission/validator/helper.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core"
+
+	"github.com/gardener/gardener-extension-registry-cache/pkg/constants"
+)
+
+// FindRegistryCacheExtension finds the registry-cache extension.
+// The first return argument is whether the extension was found.
+// The second return argument is index of the extension in the list. -1 is returned if the extension is not found.
+// The third return arguement is the extension itself. An empty extension is returned if the extension is not found.
+func FindRegistryCacheExtension(extensions []core.Extension) (bool, int, core.Extension) {
+	for i, ext := range extensions {
+		if ext.Type == constants.ExtensionType {
+			return true, i, ext
+		}
+	}
+
+	return false, -1, core.Extension{}
+}

--- a/pkg/admission/validator/helper.go
+++ b/pkg/admission/validator/helper.go
@@ -21,15 +21,14 @@ import (
 )
 
 // FindRegistryCacheExtension finds the registry-cache extension.
-// The first return argument is whether the extension was found.
-// The second return argument is index of the extension in the list. -1 is returned if the extension is not found.
-// The third return arguement is the extension itself. An empty extension is returned if the extension is not found.
-func FindRegistryCacheExtension(extensions []core.Extension) (bool, int, core.Extension) {
+// The first return argument is index of the extension in the list. -1 is returned if the extension is not found.
+// The second return argument is the extension itself. An empty extension is returned if the extension is not found.
+func FindRegistryCacheExtension(extensions []core.Extension) (int, core.Extension) {
 	for i, ext := range extensions {
 		if ext.Type == constants.ExtensionType {
-			return true, i, ext
+			return i, ext
 		}
 	}
 
-	return false, -1, core.Extension{}
+	return -1, core.Extension{}
 }

--- a/pkg/admission/validator/helper_test.go
+++ b/pkg/admission/validator/helper_test.go
@@ -26,20 +26,19 @@ import (
 var _ = Describe("Helpers", func() {
 
 	DescribeTable("#FindRegistryCacheExtension",
-		func(extensions []core.Extension, expectedOk bool, expectedI int, expectedExt core.Extension) {
-			ok, i, ext := validator.FindRegistryCacheExtension(extensions)
-			Expect(ok).To(Equal(expectedOk))
+		func(extensions []core.Extension, expectedI int, expectedExt core.Extension) {
+			i, ext := validator.FindRegistryCacheExtension(extensions)
 			Expect(i).To(Equal(expectedI))
 			Expect(ext).To(Equal(expectedExt))
 		},
 
 		Entry("extensions is nil",
 			nil,
-			false, -1, core.Extension{},
+			-1, core.Extension{},
 		),
 		Entry("extensions is empty",
 			[]core.Extension{},
-			false, -1, core.Extension{},
+			-1, core.Extension{},
 		),
 		Entry("no registry-cache extension",
 			[]core.Extension{
@@ -47,7 +46,7 @@ var _ = Describe("Helpers", func() {
 				{Type: "bar"},
 				{Type: "baz"},
 			},
-			false, -1, core.Extension{},
+			-1, core.Extension{},
 		),
 		Entry("with registry-cache extension",
 			[]core.Extension{
@@ -56,7 +55,7 @@ var _ = Describe("Helpers", func() {
 				{Type: "registry-cache", ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"one": "two"}`)}},
 				{Type: "baz"},
 			},
-			true, 2, core.Extension{Type: "registry-cache", ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"one": "two"}`)}},
+			2, core.Extension{Type: "registry-cache", ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"one": "two"}`)}},
 		),
 	)
 })

--- a/pkg/admission/validator/helper_test.go
+++ b/pkg/admission/validator/helper_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator_test
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/gardener-extension-registry-cache/pkg/admission/validator"
+)
+
+var _ = Describe("Helpers", func() {
+
+	DescribeTable("#FindRegistryCacheExtension",
+		func(extensions []core.Extension, expectedOk bool, expectedI int, expectedExt core.Extension) {
+			ok, i, ext := validator.FindRegistryCacheExtension(extensions)
+			Expect(ok).To(Equal(expectedOk))
+			Expect(i).To(Equal(expectedI))
+			Expect(ext).To(Equal(expectedExt))
+		},
+
+		Entry("extensions is nil",
+			nil,
+			false, -1, core.Extension{},
+		),
+		Entry("extensions is empty",
+			[]core.Extension{},
+			false, -1, core.Extension{},
+		),
+		Entry("no registry-cache extension",
+			[]core.Extension{
+				{Type: "foo"},
+				{Type: "bar"},
+				{Type: "baz"},
+			},
+			false, -1, core.Extension{},
+		),
+		Entry("with registry-cache extension",
+			[]core.Extension{
+				{Type: "foo"},
+				{Type: "bar"},
+				{Type: "registry-cache", ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"one": "two"}`)}},
+				{Type: "baz"},
+			},
+			true, 2, core.Extension{Type: "registry-cache", ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"one": "two"}`)}},
+		),
+	)
+})

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -26,7 +26,6 @@ import (
 
 	api "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry"
 	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/validation"
-	"github.com/gardener/gardener-extension-registry-cache/pkg/constants"
 )
 
 // shoot validates shoots
@@ -42,22 +41,14 @@ func NewShootValidator(decoder runtime.Decoder) extensionswebhook.Validator {
 }
 
 // Validate validates the given shoot object
-func (s *shoot) Validate(_ context.Context, new, _ client.Object) error {
+func (s *shoot) Validate(_ context.Context, new, old client.Object) error {
 	shoot, ok := new.(*core.Shoot)
 	if !ok {
 		return fmt.Errorf("wrong object type %T", new)
 	}
 
-	var ext *core.Extension
-	var fldPath *field.Path
-	for i, ex := range shoot.Spec.Extensions {
-		if ex.Type == constants.ExtensionType {
-			ext = ex.DeepCopy()
-			fldPath = field.NewPath("spec", "extensions").Index(i)
-			break
-		}
-	}
-	if ext == nil {
+	ok, i, ext := FindRegistryCacheExtension(shoot.Spec.Extensions)
+	if !ok {
 		return nil
 	}
 
@@ -67,7 +58,7 @@ func (s *shoot) Validate(_ context.Context, new, _ client.Object) error {
 		}
 	}
 
-	providerConfigPath := fldPath.Child("providerConfig")
+	providerConfigPath := field.NewPath("spec", "extensions").Index(i).Child("providerConfig")
 	if ext.ProviderConfig == nil {
 		return field.Required(providerConfigPath, "providerConfig is required for the registry-cache extension")
 	}
@@ -77,5 +68,30 @@ func (s *shoot) Validate(_ context.Context, new, _ client.Object) error {
 		return fmt.Errorf("failed to decode providerConfig: %w", err)
 	}
 
-	return validation.ValidateRegistryConfig(registryConfig, providerConfigPath).ToAggregate()
+	allErrs := field.ErrorList{}
+
+	if old != nil {
+		oldShoot, ok := old.(*core.Shoot)
+		if !ok {
+			return fmt.Errorf("wrong object type %T for old object", old)
+		}
+
+		oldOk, _, oldExt := FindRegistryCacheExtension(oldShoot.Spec.Extensions)
+		if oldOk {
+			if oldExt.ProviderConfig == nil {
+				return fmt.Errorf("providerConfig is not available on old Shoot")
+			}
+
+			oldRegistryConfig := &api.RegistryConfig{}
+			if err := runtime.DecodeInto(s.decoder, oldExt.ProviderConfig.Raw, oldRegistryConfig); err != nil {
+				return fmt.Errorf("failed to decode providerConfig: %w", err)
+			}
+
+			allErrs = append(allErrs, validation.ValidateRegistryConfigUpdate(oldRegistryConfig, registryConfig, providerConfigPath)...)
+		}
+	}
+
+	allErrs = append(allErrs, validation.ValidateRegistryConfig(registryConfig, providerConfigPath)...)
+
+	return allErrs.ToAggregate()
 }

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -47,8 +47,8 @@ func (s *shoot) Validate(_ context.Context, new, old client.Object) error {
 		return fmt.Errorf("wrong object type %T", new)
 	}
 
-	ok, i, ext := FindRegistryCacheExtension(shoot.Spec.Extensions)
-	if !ok {
+	i, ext := FindRegistryCacheExtension(shoot.Spec.Extensions)
+	if i == -1 {
 		return nil
 	}
 
@@ -76,8 +76,8 @@ func (s *shoot) Validate(_ context.Context, new, old client.Object) error {
 			return fmt.Errorf("wrong object type %T for old object", old)
 		}
 
-		oldOk, _, oldExt := FindRegistryCacheExtension(oldShoot.Spec.Extensions)
-		if oldOk {
+		oldI, oldExt := FindRegistryCacheExtension(oldShoot.Spec.Extensions)
+		if oldI != -1 {
 			if oldExt.ProviderConfig == nil {
 				return fmt.Errorf("providerConfig is not available on old Shoot")
 			}

--- a/pkg/apis/registry/helper/helper.go
+++ b/pkg/apis/registry/helper/helper.go
@@ -20,7 +20,7 @@ import (
 
 // FindCacheByUpstream finds a cache by upstream.
 // The first return argument is whether the extension was found.
-// The third return arguement is the cache itself. An empty cache is returned if the cache is not found.
+// The second return argument is the cache itself. An empty cache is returned if the cache is not found.
 func FindCacheByUpstream(caches []registry.RegistryCache, upstream string) (bool, registry.RegistryCache) {
 	for _, cache := range caches {
 		if cache.Upstream == upstream {

--- a/pkg/apis/registry/helper/helper.go
+++ b/pkg/apis/registry/helper/helper.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry"
+)
+
+// FindCacheByUpstream finds a cache by upstream.
+// The first return argument is whether the extension was found.
+// The third return arguement is the cache itself. An empty cache is returned if the cache is not found.
+func FindCacheByUpstream(caches []registry.RegistryCache, upstream string) (bool, registry.RegistryCache) {
+	for _, cache := range caches {
+		if cache.Upstream == upstream {
+			return true, cache
+		}
+	}
+
+	return false, registry.RegistryCache{}
+}

--- a/pkg/apis/registry/helper/helper_test.go
+++ b/pkg/apis/registry/helper/helper_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/helper"
+)
+
+func TestHelper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "APIs Registry Helper Suite")
+}
+
+var _ = Describe("Helpers", func() {
+	size := resource.MustParse("5Gi")
+
+	DescribeTable("#FindRegistryCacheExtension",
+		func(caches []registry.RegistryCache, upstream string, expectedOk bool, expectedCache registry.RegistryCache) {
+			ok, cache := helper.FindCacheByUpstream(caches, upstream)
+			Expect(ok).To(Equal(expectedOk))
+			Expect(cache).To(Equal(expectedCache))
+		},
+		Entry("caches is nil",
+			nil,
+			"docker.io",
+			false, registry.RegistryCache{},
+		),
+		Entry("caches is empty",
+			[]registry.RegistryCache{},
+			"docker.io",
+			false, registry.RegistryCache{},
+		),
+		Entry("no cache with the given upsteam",
+			[]registry.RegistryCache{{Upstream: "gcr.io"}, {Upstream: "quay.io"}, {Upstream: "registry.k8s.io"}},
+			"docker.io",
+			false, registry.RegistryCache{},
+		),
+		Entry("with cache with the given upsteam",
+			[]registry.RegistryCache{{Upstream: "gcr.io"}, {Upstream: "quay.io"}, {Upstream: "docker.io", Size: &size}, {Upstream: "registry.k8s.io"}},
+			"docker.io",
+			true, registry.RegistryCache{Upstream: "docker.io", Size: &size},
+		),
+	)
+})

--- a/pkg/apis/registry/validation/validation_test.go
+++ b/pkg/apis/registry/validation/validation_test.go
@@ -148,9 +148,11 @@ var _ = Describe("Validation", func() {
 		It("should allow valid configuration update", func() {
 			size := resource.MustParse("5Gi")
 			newCache := api.RegistryCache{
-				Upstream:                 "docker.io",
-				Size:                     &size,
-				GarbageCollectionEnabled: pointer.Bool(true),
+				Upstream: "docker.io",
+				Size:     &size,
+				GarbageCollection: &api.GarbageCollection{
+					Enabled: true,
+				},
 			}
 			registryConfig.Caches = append(registryConfig.Caches, newCache)
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -53,6 +53,7 @@ build:
         - pkg/admission/cmd
         - pkg/admission/validator
         - pkg/apis/registry
+        - pkg/apis/registry/helper
         - pkg/apis/registry/install
         - pkg/apis/registry/v1alpha1
         - pkg/apis/registry/validation


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Currently we are using StatefulSet volumeClaimTemplate to provision the PVC. However the corresponding StatefulSet field that controls the PVC size is immutable. It is not possible to resize/enlarge the underlying PVC through the StatefulSet spec. See https://github.com/kubernetes/enhancements/issues/661 This commit makes the cache size field immutable until we decide how to implement the resize.

GRM currently does not try to update the `volumeClaimTemplates` of a StatefulSet as the field is immutable. See https://github.com/gardener/gardener/blob/292970d299b4a5b113c148fc23488b11542c8dd5/pkg/resourcemanager/controller/managedresource/merger.go#L284-L287. Hence, updating the cache's size via the Shoot spec gives the impression that the update went through and was successful but actually the update does not happen at all.

**Which issue(s) this PR fixes**:
Part of #3 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
