### PR TITLE
Set `priorityClassName` for the registry cache Pods

### DIFF
--- a/pkg/component/registrycaches/registrycaches.go
+++ b/pkg/component/registrycaches/registrycaches.go
@@ -196,6 +196,7 @@ func computeResourcesDataForRegistryCache(cache *v1alpha1.RegistryCache, image s
 						Labels: labels,
 					},
 					Spec: corev1.PodSpec{
+						PriorityClassName: "system-cluster-critical",
 						Containers: []corev1.Container{
 							{
 								Name:            "registry-cache",

--- a/pkg/component/registrycaches/registrycaches_test.go
+++ b/pkg/component/registrycaches/registrycaches_test.go
@@ -172,6 +172,7 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/registry
           name: cache-volume
+      priorityClassName: system-cluster-critical
   updateStrategy: {}
   volumeClaimTemplates:
   - metadata:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Currently the registry Pods don't have a PriorityClass set:
```
% k -n registry-cache get po -o json | jq -c '.items[] | {name: .metadata.name, priority: .spec.priority}'
{"name":"registry-eu-gcr-io-0","priority":0}
{"name":"registry-quay-io-0","priority":0}
{"name":"registry-registry-k8s-io-0","priority":0}
```

This PR sets the PriorityClass to `system-cluster-critical`. See https://github.com/gardener/gardener/blob/v1.79.1/docs/development/priority-classes.md

The reasoning the choosing `system-cluster-critical` is:
> - When a request against the registry cache fails, containerd will retry the request against the upstream registry. When the registry cache is unavailable, a request times out in 30s and then the retry against the upstream happens. In that case, the image pull time increases significantly because containerd performs multiple requests (HEAD request to resolve the manifest by tag, GET request for the manifest by SHA, GET requests for blobs) and each of these requests times out in 30s. For example, image pull from the upstream for `docker.io/library/alpine:3.13.2` takes ~2s while image pull of the same image with unavailable registry cache takes ~2m.2s. Another example - image pull from the upstream for `eu.gcr.io/gardener-project/gardener/ops-toolbelt:0.18.0` takes ~10s while image pull of the same image with unavailable registry cache takes ~3m.10s.

**Which issue(s) this PR fixes**:
Part of #3

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
