### PR TITLE
Use `kube-system` namespace to deploy registry cache extension

### DIFF
--- a/pkg/component/registrycaches/registrycaches.go
+++ b/pkg/component/registrycaches/registrycaches.go
@@ -122,13 +122,7 @@ func (r *registryCaches) WaitCleanup(ctx context.Context) error {
 }
 
 func (r *registryCaches) computeResourcesData() (map[string][]byte, error) {
-	objects := []client.Object{
-		&corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: constants.NamespaceRegistryCache,
-			},
-		},
-	}
+	var objects []client.Object
 
 	for _, cache := range r.values.Caches {
 		cacheObjects, err := computeResourcesDataForRegistryCache(&cache, r.values.Image)
@@ -164,7 +158,7 @@ func computeResourcesDataForRegistryCache(cache *v1alpha1.RegistryCache, image s
 		service = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
-				Namespace: constants.NamespaceRegistryCache,
+				Namespace: metav1.NamespaceSystem,
 				Labels:    labels,
 			},
 			Spec: corev1.ServiceSpec{
@@ -182,7 +176,7 @@ func computeResourcesDataForRegistryCache(cache *v1alpha1.RegistryCache, image s
 		statefulSet = &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
-				Namespace: constants.NamespaceRegistryCache,
+				Namespace: metav1.NamespaceSystem,
 				Labels:    labels,
 			},
 			Spec: appsv1.StatefulSetSpec{

--- a/pkg/component/registrycaches/registrycaches_test.go
+++ b/pkg/component/registrycaches/registrycaches_test.go
@@ -99,14 +99,6 @@ var _ = Describe("RegistryCaches", func() {
 
 	Describe("#Deploy", func() {
 		var (
-			namespaceYAML = `apiVersion: v1
-kind: Namespace
-metadata:
-  creationTimestamp: null
-  name: registry-cache
-spec: {}
-status: {}
-`
 			serviceYAMLFor = func(name, upstream string) string {
 				return `apiVersion: v1
 kind: Service
@@ -116,7 +108,7 @@ metadata:
     app: ` + name + `
     upstream-host: ` + upstream + `
   name: ` + name + `
-  namespace: registry-cache
+  namespace: kube-system
 spec:
   ports:
   - name: registry-cache
@@ -141,7 +133,7 @@ metadata:
     app: ` + name + `
     upstream-host: ` + upstream + `
   name: ` + name + `
-  namespace: registry-cache
+  namespace: kube-system
 spec:
   replicas: 1
   selector:
@@ -258,12 +250,11 @@ status:
 			Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
 			Expect(managedResourceSecret.Immutable).To(Equal(pointer.Bool(true)))
 			Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
-			Expect(managedResourceSecret.Data).To(HaveLen(5))
-			Expect(string(managedResourceSecret.Data["namespace____registry-cache.yaml"])).To(Equal(namespaceYAML))
-			Expect(string(managedResourceSecret.Data["service__registry-cache__registry-docker-io.yaml"])).To(Equal(serviceYAMLFor("registry-docker-io", "docker.io")))
-			Expect(string(managedResourceSecret.Data["statefulset__registry-cache__registry-docker-io.yaml"])).To(Equal(statefulSetYAMLFor("registry-docker-io", "docker.io", "https://registry-1.docker.io", "10Gi", true)))
-			Expect(string(managedResourceSecret.Data["service__registry-cache__registry-eu-gcr-io.yaml"])).To(Equal(serviceYAMLFor("registry-eu-gcr-io", "eu.gcr.io")))
-			Expect(string(managedResourceSecret.Data["statefulset__registry-cache__registry-eu-gcr-io.yaml"])).To(Equal(statefulSetYAMLFor("registry-eu-gcr-io", "eu.gcr.io", "https://eu.gcr.io", "20Gi", false)))
+			Expect(managedResourceSecret.Data).To(HaveLen(4))
+			Expect(string(managedResourceSecret.Data["service__kube-system__registry-docker-io.yaml"])).To(Equal(serviceYAMLFor("registry-docker-io", "docker.io")))
+			Expect(string(managedResourceSecret.Data["statefulset__kube-system__registry-docker-io.yaml"])).To(Equal(statefulSetYAMLFor("registry-docker-io", "docker.io", "https://registry-1.docker.io", "10Gi", true)))
+			Expect(string(managedResourceSecret.Data["service__kube-system__registry-eu-gcr-io.yaml"])).To(Equal(serviceYAMLFor("registry-eu-gcr-io", "eu.gcr.io")))
+			Expect(string(managedResourceSecret.Data["statefulset__kube-system__registry-eu-gcr-io.yaml"])).To(Equal(statefulSetYAMLFor("registry-eu-gcr-io", "eu.gcr.io", "https://eu.gcr.io", "20Gi", false)))
 		})
 	})
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -18,8 +18,6 @@ const (
 	// ExtensionType is the name of the extension type.
 	ExtensionType = "registry-cache"
 
-	// NamespaceRegistryCache is the namespace where the registry cache resources are deployed.
-	NamespaceRegistryCache = "registry-cache"
 	// UpstreamHostLabel is a label on registry cache resources (Service, StatefulSet) which denotes the upstream host.
 	UpstreamHostLabel = "upstream-host"
 	// RegistryCachePort is the port on which the pull through cache serves requests.

--- a/pkg/controller/extension/actuator.go
+++ b/pkg/controller/extension/actuator.go
@@ -139,7 +139,7 @@ func (a *actuator) computeProviderStatus(ctx context.Context, registryConfig *v1
 
 	// get all registry cache services
 	services := &corev1.ServiceList{}
-	if err := shootClient.List(ctx, services, client.InNamespace(constants.NamespaceRegistryCache), client.MatchingLabelsSelector{Selector: selector}); err != nil {
+	if err := shootClient.List(ctx, services, client.InNamespace(metav1.NamespaceSystem), client.MatchingLabelsSelector{Selector: selector}); err != nil {
 		return nil, fmt.Errorf("failed to read services from shoot: %w", err)
 	}
 

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -158,7 +158,7 @@ func verifyRegistryCache(parentCtx context.Context, log logr.Logger, shootClient
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"upstream-host": upstream}))
 	var reader io.Reader
 	EventuallyWithOffset(1, ctx, func(g Gomega) (err error) {
-		reader, err = framework.PodExecByLabel(ctx, selector, "registry-cache", "cat /var/lib/registry/scheduler-state.json", "registry-cache", shootClient)
+		reader, err = framework.PodExecByLabel(ctx, selector, "registry-cache", "cat /var/lib/registry/scheduler-state.json", metav1.NamespaceSystem, shootClient)
 		return err
 	}).WithPolling(10*time.Second).Should(Succeed(), "Expected to successfully cat registry's scheduler-state.json file")
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area metering
/area logging
/kind enhancement

**What this PR does / why we need it**:

Switch registry cache namespace from `registry-cache` to `kube-system`.

When registry cache stateful sets are deployed in `registry-cache` namespace into the `Shoot` cluster:
- no kubelet metrics for the `pods` (such as cpu/memory usage) and for the `volumes` (volume capacity and usage) metrics are be scraped.
- no logs from registry `pods` are be scraped.

Additionally, after https://github.com/gardener/gardener/pull/8483 we can no longer use the `registry-cache` Namespace. GRM fails because `registry-cache` is unknown namespace for cache:
```yaml
  - lastTransitionTime: "2023-09-25T12:39:28Z"
    lastUpdateTime: "2023-09-25T12:36:38Z"
    message: 'error during apply of object "v1/Service/registry-cache/registry-docker-io":
      unable to get: registry-cache/registry-docker-io because of unknown namespace
      for the cache'
    reason: ApplyFailed
    status: "False"
    type: ResourcesApplied
```

If the namespace is switched to `kube-system` monitoring and logging will automatically scrape the required metrics and logs.

**Which issue(s) this PR fixes**:
Part of #3 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The registry cache namespace is switched from `registry-cache` to `kube-system`.
```
