### PR TITLE
Add readiness and liveness probe to the registry Pods

### DIFF
--- a/pkg/component/registrycaches/registrycaches_test.go
+++ b/pkg/component/registrycaches/registrycaches_test.go
@@ -154,12 +154,32 @@ spec:
           value: ` + upstreamURL + `
         - name: REGISTRY_STORAGE_DELETE_ENABLED
           value: "` + strconv.FormatBool(garbageCollectionEnabled) + `"
+        - name: REGISTRY_HTTP_ADDR
+          value: :5000
+        - name: REGISTRY_HTTP_DEBUG_ADDR
+          value: :5001
         image: ` + image + `
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /debug/health
+            port: 5001
+          periodSeconds: 20
+          successThreshold: 1
         name: registry-cache
         ports:
         - containerPort: 5000
           name: registry-cache
+        - containerPort: 5001
+          name: debug
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /debug/health
+            port: 5001
+          periodSeconds: 20
+          successThreshold: 1
         resources: {}
         volumeMounts:
         - mountPath: /var/lib/registry


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adds liveness and readiness probes to the registry Pods.

~~I was wondering which endpoint to use for the probes. There is `/debug/health` when debug is enabled  but it is not recommended for production environments (ref https://docs.docker.com/registry/configuration/#debug):~~
> Sensitive information may be available via the debug endpoint. Please be certain that access to the debug endpoint is locked down in a production environment.

~~I used `/` from after I inspired from an upstream chart (ref https://github.com/phntom/charts/blob/1927af1c70a919284241ed04669a566b39f675c2/docker-registry/templates/deployment.yaml#L57-L70).~~

See https://github.com/distribution/distribution/issues/4085#issuecomment-1741727457

**Which issue(s) this PR fixes**:
Part of #3 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
