### PR TITLE
skaffold: Rebuild when there are changes to `go:embed` files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,10 @@ check-generate:
 	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check-generate.sh $(REPO_ROOT)
 
 .PHONY: check
-check: $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM)
+check: $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM) $(YQ)
 	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check.sh --golangci-lint-config=./.golangci.yaml ./cmd/... ./pkg/... ./test/...
 	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/check-charts.sh ./charts
+	@hack/check-skaffold-deps.sh
 
 .PHONY: generate
 generate: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(HELM) $(YQ)

--- a/hack/check-skaffold-deps.sh
+++ b/hack/check-skaffold-deps.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+echo "> Check Skaffold Dependencies"
+
+check_successful=true
+
+out_dir=$(mktemp -d)
+function cleanup_output {
+  rm -rf "$out_dir"
+}
+trap cleanup_output EXIT
+
+function check() {
+  skaffold_file="$1"
+  binary_name="$2"
+  skaffold_config_name="$3"
+
+  skaffold_yaml="$(cat "$(dirname "$0")/../$skaffold_file")"
+
+  path_current_skaffold_dependencies="${out_dir}/current-$skaffold_file-deps-$binary_name.txt"
+  path_actual_dependencies="${out_dir}/actual-$skaffold_file-deps-$binary_name.txt"
+
+  echo "$skaffold_yaml" |\
+    yq eval "select(.metadata.name == \"$skaffold_config_name\") | .build.artifacts[] | select(.ko.main == \"./cmd/$binary_name\") | .ko.dependencies.paths[]?" - |\
+    sort |\
+    uniq > "$path_current_skaffold_dependencies"
+
+  go list -f '{{ join .Deps "\n" }}' "./cmd/$binary_name" |\
+    grep "github.com/gardener/gardener-extension-registry-cache/" |\
+    sed 's/github\.com\/gardener\/gardener-extension-registry-cache\///g' |\
+    sort |\
+    uniq > "$path_actual_dependencies"
+
+  # always add vendor directory and VERSION file
+  echo "vendor" >> "$path_actual_dependencies"
+  echo "VERSION" >> "$path_actual_dependencies"
+
+  # sort dependencies
+  sort -o $path_current_skaffold_dependencies{,}
+  sort -o $path_actual_dependencies{,}
+
+  echo -n ">> Checking defined dependencies in Skaffold config '$skaffold_config_name' for '$binary_name' in '$skaffold_file'..."
+  if ! diff="$(diff "$path_current_skaffold_dependencies" "$path_actual_dependencies")"; then
+    check_successful=false
+
+    echo
+    echo ">>> The following actual dependencies are missing in $skaffold_file (need to be added):"
+    echo "$diff" | grep '>' | awk '{print $2}'
+    echo
+    echo ">>> The following dependencies defined in $skaffold_file are not needed actually (need to be removed):"
+    echo "$diff" | grep '<' | awk '{print $2}'
+    echo
+  else
+    echo " success."
+  fi
+}
+
+check "skaffold.yaml" "gardener-extension-registry-cache" "extension"
+check "skaffold.yaml" "gardener-extension-registry-cache-admission" "admission"
+
+if [ "$check_successful" = false ] ; then
+  exit 1
+fi

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -17,6 +17,7 @@ build:
         - pkg/apis/registry
         - pkg/apis/registry/install
         - pkg/apis/registry/v1alpha1
+        - pkg/apis/registry/v1alpha1/helper
         - pkg/cmd
         - pkg/component/registrycaches
         - pkg/constants

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,6 +7,25 @@ build:
   artifacts:
   - image: eu.gcr.io/gardener-project/gardener/extensions/registry-cache
     ko:
+      dependencies:
+        paths:
+        - charts
+        - cmd/gardener-extension-registry-cache/app
+        - pkg/apis/config
+        - pkg/apis/config/v1alpha1
+        - pkg/apis/config/validation
+        - pkg/apis/registry
+        - pkg/apis/registry/install
+        - pkg/apis/registry/v1alpha1
+        - pkg/cmd
+        - pkg/component/registrycaches
+        - pkg/constants
+        - pkg/controller/extension
+        - pkg/imagevector
+        - pkg/utils/registry
+        - pkg/webhook/operatingsystemconfig
+        - vendor
+        - VERSION
       main: ./cmd/gardener-extension-registry-cache
 resourceSelector:
   allow:
@@ -27,6 +46,18 @@ build:
   artifacts:
   - image: eu.gcr.io/gardener-project/gardener/extensions/registry-cache-admission
     ko:
+      dependencies:
+        paths:
+        - cmd/gardener-extension-registry-cache-admission/app
+        - pkg/admission/cmd
+        - pkg/admission/validator
+        - pkg/apis/registry
+        - pkg/apis/registry/install
+        - pkg/apis/registry/v1alpha1
+        - pkg/apis/registry/validation
+        - pkg/constants
+        - vendor
+        - VERSION
       main: ./cmd/gardener-extension-registry-cache-admission
 deploy:
   helm:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Currently, the ko builder does not detect changes to `go:embed` files (see https://github.com/GoogleContainerTools/skaffold/issues/7836). This makes impossible the development of some scripts that are used later by `go:embed`. This PR inspires from https://github.com/gardener/gardener/pull/6735 and https://github.com/gardener/gardener/pull/6781 and does the same setup for the registry-cache extension.

**Which issue(s) this PR fixes**:
Part of #3

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
