### PR TITLE
Fix `make extension-up` against new Docker Desktop versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ PARALLEL_E2E_TESTS          := 2
 #########################################
 
 TOOLS_DIR := hack/tools
+# TODO(ialidzhikov): Remove this version pin when the skaffold version coming from gardener/gardener is higher than or equal to v2.8.0.
+# skaffold@v2.8.0 contains https://github.com/GoogleContainerTools/skaffold/pull/9094 which fixes skaffold to correctly find the docker socket location.
+SKAFFOLD_VERSION := v2.8.0
 include $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/tools.mk
 
 #################################################################


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
`make extension-up` fails with:
```
Checking cache...
 - eu.gcr.io/gardener-project/gardener/extensions/registry-cache: Error checking cache.
getting imageID for eu.gcr.io/gardener-project/gardener/extensions/registry-cache:v0.1.0-34-g935efc92-dirty: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

For a long time I was performing the following workaround:
```
% sudo ln -s "$HOME/.docker/run/docker.sock" /var/run/docker.sock
```

It seems that the issue is fixed permanently in `skaffold@v2.8.0` with https://github.com/GoogleContainerTools/skaffold/pull/9094. skaffold should now be able to correctly determine to location of the docker socket.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
