### PR TITLE
Address TODO related to admission Pod labels

### DIFF
--- a/charts/admission/charts/runtime/templates/deployment.yaml
+++ b/charts/admission/charts/runtime/templates/deployment.yaml
@@ -20,10 +20,6 @@ spec:
         checksum/secret-kubeconfig: {{ include (print $.Template.BasePath "/secret-kubeconfig.yaml") . | sha256sum }}
         {{- end }}
       labels:
-        # TODO(ialidzhikov): Double check whether we need these NetworkPolicy labels.
-        networking.gardener.cloud/to-dns: allowed
-        networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443: allowed
-        networking.gardener.cloud/to-runtime-apiserver: allowed
 {{ include "labels" . | indent 8 }}
     spec:
       {{- if not .Values.global.virtualGarden.enabled }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
Right now the admission does not have a client and does not do requests against the virtual kube-apiserver or the runtime kube-apiserver. In future we might need to introduce such client (when validating the registry cache credentials) but currently the admission components don't need access to DNS, virtual kube-apiserver or runtime kube-apiserver.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
