### PR TITLE
Reduce e2e test flakes due to transient network errors

### DIFF
--- a/test/common/common.go
+++ b/test/common/common.go
@@ -103,8 +103,8 @@ func WaitUntilRegistryConfigurationsAreApplied(ctx context.Context, log logr.Log
 
 		EventuallyWithOffset(1, ctx, func(g Gomega) string {
 			command := "systemctl is-active configure-containerd-registries.service &>/dev/null && echo 'active' || echo 'not active'"
-			response, err := rootPodExecutor.Execute(ctx, command)
-			Expect(err).NotTo(HaveOccurred())
+			// err is ignored intentionally to reduce flakes from transient network errors in prow.
+			response, _ := rootPodExecutor.Execute(ctx, command)
 
 			return string(response)
 		}).WithPolling(10*time.Second).Should(Equal("active\n"), fmt.Sprintf("Expected the configure-containerd-registries.service unit to be active on node %s", node.Name))
@@ -127,8 +127,8 @@ func VerifyRegistryConfigurationsAreRemoved(ctx context.Context, log logr.Logger
 
 		EventuallyWithOffset(1, ctx, func(g Gomega) string {
 			command := "systemctl status configure-containerd-registries.service &>/dev/null && echo 'unit found' || echo 'unit not found'"
-			response, err := rootPodExecutor.Execute(ctx, command)
-			Expect(err).NotTo(HaveOccurred())
+			// err is ignored intentionally to reduce flakes from transient network errors in prow.
+			response, _ := rootPodExecutor.Execute(ctx, command)
 
 			return string(response)
 		}).WithPolling(10*time.Second).Should(Equal("unit not found\n"), fmt.Sprintf("Expected the configure-containerd-registries.service systemd unit on node %s to be deleted", node.Name))
@@ -136,8 +136,8 @@ func VerifyRegistryConfigurationsAreRemoved(ctx context.Context, log logr.Logger
 		for _, upstream := range upstreams {
 			EventuallyWithOffset(1, ctx, func(g Gomega) string {
 				command := fmt.Sprintf("[ -f /etc/containerd/certs.d/%s/hosts.toml ] && echo 'file found' || echo 'file not found'", upstream)
-				response, err := rootPodExecutor.Execute(ctx, command)
-				Expect(err).NotTo(HaveOccurred())
+				// err is ignored intentionally to reduce flakes from transient network errors in prow.
+				response, _ := rootPodExecutor.Execute(ctx, command)
 
 				return string(response)
 			}).WithPolling(10*time.Second).Should(Equal("file not found\n"), fmt.Sprintf("Expected hosts.toml file on node %s for upstream %s to be deleted", node.Name, upstream))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
We have many e2e flakes of type:
```
  [FAILED] Unexpected error:
      <*errors.StatusError | 0xc0001519a0>: 
      error dialing backend: dial tcp 10.2.2.180:9443: connect: connection refused
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "error dialing backend: dial tcp 10.2.2.180:9443: connect: connection refused",
              Reason: "",
              Details: nil,
              Code: 500,
          },
      }
  occurred
  In [It] at: /home/prow/go/src/github.com/gardener/gardener-extension-registry-cache/test/common/common.go:107 @ 10/19/23 12:52:30.439
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
