### PR TITLE
Do not deploy the `registry-configuration-cleaner` on Shoot deletion

### DIFF
--- a/docs/development/extension-registry-cache.md
+++ b/docs/development/extension-registry-cache.md
@@ -6,6 +6,10 @@ This document outlines how the Shoot reconciliation and deletion work for a Shoo
 
 This section outlines how the reconciliation works for a Shoot with the registry-cache extension enabled.
 
+#### Extension enablement/reconciliation
+
+This section outlines how the extension enablement/reconciliation works, e.g the extension has beeen added to the Shoot spec.
+
 1. As part of the Shoot reconciliation flow, gardenlet deploys the [Extension](https://github.com/gardener/gardener/blob/v1.82.0/docs/extensions/extension.md) resource.
 1. The registry-cache extension reconciles the Extension resource. [pkg/controller/extension/actuator.go](../../pkg/controller/extension/actuator.go) contains the implementation of the [extension.Actuator](https://github.com/gardener/gardener/blob/v1.82.0/extensions/pkg/controller/extension/actuator.go) interface. The reconciliation of an Extension of type `registry-cache` consists of the following steps:
    1. The extension checks if a registry has been removed (by comparing the status and the spec of the Extension). If an upstream is being removed, then it deploys the [`registry-cleaner` DaemonSet](../../pkg/component/registryconfigurationcleaner/registry_configuration_cleaner.go) to the Shoot cluster to clean up the existing configuration for the upstream that has to be removed.
@@ -17,10 +21,18 @@ This section outlines how the reconciliation works for a Shoot with the registry
    1. The webhook appends the [configure-containerd-registries.sh](../../pkg/webhook/operatingsystemconfig/scripts/configure-containerd-registries.sh) script to the OperatingSystemConfig files. The script accepts registries in the format `<upstream_host>,<registry_cache_endpoint>,<upstream_url>` separated by a space. For each given registry the script waits until the given registry is available (a request to the `<registry_cache_endpoint>` succeeds). Then it creates a `hosts.toml` file for the given `<upstream_host>`. In short, the `hosts.toml` file instructs containerd to first try to pull images for the given `<upstream_host>` from the configured `<registry_cache_endpoint>`. For more information about containerd registry configuration, see the [containerd documentation](https://github.com/containerd/containerd/blob/main/docs/hosts.md). The motivation to introduce the `configure-containerd-registries.sh` script is that we need to create the `hosts.toml` file when the corresponding registry is available. For more details, see https://github.com/gardener/gardener-extension-registry-cache/pull/68.
    1. The webhook appends the `configure-containerd-registries.service` unit to the OperatingSystemConfig units. The webhook fetches the Extension resource and then it configures the unit to invoke the `configure-containerd-registries.sh` script with the registries from the Extension status.
 
+#### Extension disablement
+
+This section outlines how the extension disablement works, i.e the extension has be removed from the Shoot spec.
+
+1. As part of the Shoot reconciliation flow, gardenlet destroys the [Extension](https://github.com/gardener/gardener/blob/v1.82.0/docs/extensions/extension.md) resource because it is no longer needed.
+   1. If the Extension resource contains registries in its status, the registry-cache extension deploys the [`registry-cleaner` DaemonSet](../../pkg/component/registryconfigurationcleaner/registry_configuration_cleaner.go) to the Shoot cluster to clean up the existing registry configuration.
+   1. The extension deletes the ManagedResource containing the registry cache resources.
+
 ## Shoot deletion
 
 This section outlines how the deletion works for a Shoot with the registry-cache extension enabled.
 
 1. As part of the Shoot deletion flow, gardenlet destroys the [Extension](https://github.com/gardener/gardener/blob/v1.82.0/docs/extensions/extension.md) resource.
-   1. If the Extension resource contains registries in its status, the registry-cache extension deploys the [`registry-cleaner` DaemonSet](../../pkg/component/registryconfigurationcleaner/registry_configuration_cleaner.go) to the Shoot cluster to clean up the existing configuration for the registries.
+   1. In the Shoot deletion flow the Extension resource is deleted after the Worker resource. Hence, there is no need to deploy the [`registry-cleaner` DaemonSet](../../pkg/component/registryconfigurationcleaner/registry_configuration_cleaner.go) to the Shoot cluster to clean up the existing registry configuration.
    1. The extension deletes the ManagedResource containing the registry cache resources.

--- a/test/e2e/create_enable_force_delete_test.go
+++ b/test/e2e/create_enable_force_delete_test.go
@@ -56,6 +56,7 @@ var _ = Describe("Registry Cache Extension Tests", func() {
 		ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)
 		defer cancel()
 		common.WaitUntilRegistryConfigurationsAreApplied(ctx, f.Logger, f.ShootFramework.ShootClient)
+
 		By("Verify registry-cache works")
 		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootFramework.ShootClient, "docker.io", common.DockerNginx1130ImageWithDigest)
 


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
If the Shoot is in deletion, then there is no need to clean up the registry configuration from Nodes. The Shoot deletion flows ensures that the Worker is deleted before the Extension deletion. 
https://github.com/gardener/gardener/blob/6f8ce7692f793e583734f533cfdee7b9d93fb815/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go#L436-L440

The `deleteExtensionResourcesBeforeKubeAPIServer` step depends on `waitUntilManagedResourcesDeleted` which depends on `deleteManagedResources` which depends on `waitUntilWorkerDeleted`.

Hence, there are no Nodes, no need to clean up registry configuration.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `registry-configuration-cleaner` is no longer deployed on Shoot deletion with registry-cache extension enabled. The Extension deletion occurs after the Worker deletion. There are no Nodes, hence there is no need to clean up registry configuration.
```
