### PR TITLE
Extend the default e2e test to test upstream addition and removal

### DIFF
--- a/pkg/apis/registry/helper/helper_test.go
+++ b/pkg/apis/registry/helper/helper_test.go
@@ -33,7 +33,7 @@ func TestHelper(t *testing.T) {
 var _ = Describe("Helpers", func() {
 	size := resource.MustParse("5Gi")
 
-	DescribeTable("#FindRegistryCacheExtension",
+	DescribeTable("#FindCacheByUpstream",
 		func(caches []registry.RegistryCache, upstream string, expectedOk bool, expectedCache registry.RegistryCache) {
 			ok, cache := helper.FindCacheByUpstream(caches, upstream)
 			Expect(ok).To(Equal(expectedOk))

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -50,10 +50,12 @@ const (
 	EuGcrNginx1176ImageWithDigest = "eu.gcr.io/gardener-project/3rd/nginx@sha256:3efdd8ec67f2eb4e96c6f49560f20d6888242f1376808b84ed0ceb064dceae11"
 	// RegistryK8sNginx1154ImageWithDigest corresponds to the registry.k8s.io/e2e-test-images/nginx:1.15-4 image.
 	RegistryK8sNginx1154ImageWithDigest = "registry.k8s.io/e2e-test-images/nginx@sha256:db048754ae68ae337d8fa96494c96d2a1204c3320f5dcf7e8e71085adec85da6"
+	// PublicEcrAwsNginx1199ImageWithDigest corresponds to the public.ecr.aws/nginx/nginx:1.19.9 image.
+	PublicEcrAwsNginx1199ImageWithDigest = "public.ecr.aws/nginx/nginx@sha256:f248a8862fa9b21badbe043518f52f143946e2dc705300e8534f8ca624a291b2"
 )
 
-// AddRegistryCacheExtension adds registry-cache extension with the given caches to the given Shoot.
-func AddRegistryCacheExtension(shoot *gardencorev1beta1.Shoot, caches []v1alpha1.RegistryCache) {
+// AddOrUpdateRegistryCacheExtension adds or updates registry-cache extension with the given caches to the given Shoot.
+func AddOrUpdateRegistryCacheExtension(shoot *gardencorev1beta1.Shoot, caches []v1alpha1.RegistryCache) {
 	providerConfig := &v1alpha1.RegistryConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),
@@ -71,18 +73,21 @@ func AddRegistryCacheExtension(shoot *gardencorev1beta1.Shoot, caches []v1alpha1
 		},
 	}
 
-	shoot.Spec.Extensions = append(shoot.Spec.Extensions, extension)
+	i := slices.IndexFunc(shoot.Spec.Extensions, func(ext gardencorev1beta1.Extension) bool {
+		return ext.Type == "registry-cache"
+	})
+	if i == -1 {
+		shoot.Spec.Extensions = append(shoot.Spec.Extensions, extension)
+	} else {
+		shoot.Spec.Extensions[i] = extension
+	}
 }
 
 // HasRegistryCacheExtension returns whether the Shoot has an extension of type registry-cache.
 func HasRegistryCacheExtension(shoot *gardencorev1beta1.Shoot) bool {
-	for _, extension := range shoot.Spec.Extensions {
-		if extension.Type == "registry-cache" {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(shoot.Spec.Extensions, func(ext gardencorev1beta1.Extension) bool {
+		return ext.Type == "registry-cache"
+	})
 }
 
 // RemoveRegistryCacheExtension removes registry caches extensions from given Shoot.
@@ -113,25 +118,28 @@ func WaitUntilRegistryConfigurationsAreApplied(ctx context.Context, log logr.Log
 	}
 }
 
-// VerifyRegistryConfigurationsAreRemoved verifies that configure-containerd-registries.service systemd unit gets deleted and the hosts.toml files for the given upstreams are removed.
-// The hosts.toml file and the systemd unit are deleted by a DaemonSet by the registry-cache extension.
+// VerifyRegistryConfigurationsAreRemoved verifies that configure-containerd-registries.service systemd unit gets deleted (if expectSystemdUnitDeletion is true)
+// and the hosts.toml files for the given upstreams are removed.
+// The hosts.toml file(s) and the systemd unit are deleted by the registry-configuration-cleaner DaemonSet.
 //
 // Note that for a Shoot cluster provider-local adds hosts.toml files for localhost:5001, gcr.io, eu.gcr.io, ghcr.io, registry.k8s.io and quay.io.
 // Hence, when a registry cache is removed for one of the above upstreams, then provider-local's hosts.toml file will still exist.
-func VerifyRegistryConfigurationsAreRemoved(ctx context.Context, log logr.Logger, shootClient kubernetes.Interface, upstreams []string) {
+func VerifyRegistryConfigurationsAreRemoved(ctx context.Context, log logr.Logger, shootClient kubernetes.Interface, expectSystemdUnitDeletion bool, upstreams []string) {
 	nodes := &corev1.NodeList{}
 	ExpectWithOffset(1, shootClient.Client().List(ctx, nodes)).To(Succeed())
 
 	for _, node := range nodes.Items {
 		rootPodExecutor := framework.NewRootPodExecutor(log, shootClient, &node.Name, "kube-system")
 
-		EventuallyWithOffset(1, ctx, func(g Gomega) string {
-			command := "systemctl status configure-containerd-registries.service &>/dev/null && echo 'unit found' || echo 'unit not found'"
-			// err is ignored intentionally to reduce flakes from transient network errors in prow.
-			response, _ := rootPodExecutor.Execute(ctx, command)
+		if expectSystemdUnitDeletion {
+			EventuallyWithOffset(1, ctx, func(g Gomega) string {
+				command := "systemctl status configure-containerd-registries.service &>/dev/null && echo 'unit found' || echo 'unit not found'"
+				// err is ignored intentionally to reduce flakes from transient network errors in prow.
+				response, _ := rootPodExecutor.Execute(ctx, command)
 
-			return string(response)
-		}).WithPolling(10*time.Second).Should(Equal("unit not found\n"), fmt.Sprintf("Expected the configure-containerd-registries.service systemd unit on node %s to be deleted", node.Name))
+				return string(response)
+			}).WithPolling(10*time.Second).Should(Equal("unit not found\n"), fmt.Sprintf("Expected the configure-containerd-registries.service systemd unit on node %s to be deleted", node.Name))
+		}
 
 		for _, upstream := range upstreams {
 			EventuallyWithOffset(1, ctx, func(g Gomega) string {

--- a/test/e2e/create_enabled_delete_shoot_system_components_test.go
+++ b/test/e2e/create_enabled_delete_shoot_system_components_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Registry Cache Extension Tests", func() {
 	f := defaultShootCreationFramework()
 	shoot := defaultShoot("e2e-default-ssc")
 	size := resource.MustParse("2Gi")
-	common.AddRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
+	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
 		{Upstream: "eu.gcr.io", Size: &size},
 		{Upstream: "quay.io", Size: &size},
 		{Upstream: "registry.k8s.io", Size: &size},

--- a/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
+++ b/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Registry Cache Extension Tests", func() {
 	f := defaultShootCreationFramework()
 	shoot := defaultShoot("e2e-hib")
 	size := resource.MustParse("2Gi")
-	common.AddRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
+	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
 		{Upstream: "docker.io", Size: &size},
 	})
 	f.Shoot = shoot

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Shoot registry cache testing", func() {
 		defer cancel()
 		Expect(f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
 			size := resource.MustParse("2Gi")
-			common.AddRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
+			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
 				{Upstream: "docker.io", Size: &size},
 			})
 
@@ -67,7 +67,7 @@ var _ = Describe("Shoot registry cache testing", func() {
 		By("Verify registry configuration is removed")
 		ctx, cancel = context.WithTimeout(parentCtx, 2*time.Minute)
 		defer cancel()
-		common.VerifyRegistryConfigurationsAreRemoved(ctx, f.Logger, f.ShootClient, []string{"docker.io"})
+		common.VerifyRegistryConfigurationsAreRemoved(ctx, f.Logger, f.ShootClient, true, []string{"docker.io"})
 	}, defaultTestTimeout, framework.WithCAfterTest(func(ctx context.Context) {
 		if common.HasRegistryCacheExtension(f.Shoot) {
 			By("Disable the registry-cache extension")

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -38,13 +38,13 @@ const (
 var _ = Describe("Shoot registry cache testing", func() {
 	f := framework.NewShootFramework(nil)
 
-	f.Serial().Beta().CIt("should enable the extension, hibernate Shoot, reconcile Shoot, wake up Shoot, disable the extension", func(parentCtx context.Context) {
+	f.Serial().Beta().CIt("should enable extension, hibernate Shoot, reconcile Shoot, wake up Shoot, disable extension", func(parentCtx context.Context) {
 		By("Enable the registry-cache extension")
 		ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()
 		Expect(f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
 			size := resource.MustParse("2Gi")
-			common.AddRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
+			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
 				{Upstream: "docker.io", Size: &size},
 			})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Currently we don't have a test where upstream addition and removal are tested. This PR covers this by extending the existing default e2e test.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
