### PR TITLE
Skip vulnerability scans for the alpine and pause images

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -7,7 +7,7 @@ images:
 # registry-configuration-cleaner DaemonSet
 - name: alpine
   repository: eu.gcr.io/gardener-project/3rd/alpine
-  tag: "3.15.8"
+  tag: "3.18.4"
   labels:
   - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
     value:

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -8,7 +8,21 @@ images:
 - name: alpine
   repository: eu.gcr.io/gardener-project/3rd/alpine
   tag: "3.15.8"
+  labels:
+  - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
+    value:
+      policy: skip
+      comment: >
+        The alpine container is not accessible from outside k8s clusters and not
+        interacted with from other containers or other systems.
 - name: pause
   sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
   repository: registry.k8s.io/pause
   tag: "3.9"
+  labels:
+  - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
+    value:
+      policy: skip
+      comment: >
+        The pause container is not accessible from outside k8s clusters and not
+        interacted with from other containers or other systems.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
The PR:
- excludes alpine and pause images from vulnerability scans
- updates alpine to 3.18.4

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
The PR depends on https://github.com/gardener/ci-infra/pull/990.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Vulnerability scans are disabled for the alpine and pause images as the corresponding containers are not accessible from outside of the K8s clusters and not interacted with from other containers or other systems.
```

```other operator
The following image is updated:
- `eu.gcr.io/gardener-project/3rd/alpin`e: 3.15.8 -> 3.18.4
```
