### PR TITLE
Fix the `--version` flag

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 **
 
 # Exclude folders relevant for build
+!.git/
 !.dockerignore
 !cmd/
 !hack/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM golang:1.21.4 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-registry-cache
 COPY . .
-RUN make install
+
+ARG EFFECTIVE_VERSION
+
+RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 
 ############# base
 FROM gcr.io/distroless/static-debian12:nonroot AS base

--- a/cmd/gardener-extension-registry-cache-admission/app/app.go
+++ b/cmd/gardener-extension-registry-cache-admission/app/app.go
@@ -23,6 +23,7 @@ import (
 	coreinstall "github.com/gardener/gardener/pkg/apis/core/install"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	"github.com/spf13/cobra"
+	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -60,6 +61,8 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			verflag.PrintAndExitIfRequested()
+
+			log.Info("Starting registry-cache-admission", "version", version.Get())
 
 			if err := aggOption.Complete(); err != nil {
 				return fmt.Errorf("error completing options: %w", err)

--- a/cmd/gardener-extension-registry-cache/app/app.go
+++ b/cmd/gardener-extension-registry-cache/app/app.go
@@ -25,13 +25,18 @@ import (
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	componentbaseconfig "k8s.io/component-base/config"
+	"k8s.io/component-base/version"
+	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	registryinstall "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/install"
 	extensioncontroller "github.com/gardener/gardener-extension-registry-cache/pkg/controller/extension"
 )
+
+var log = logf.Log.WithName("gardener-extension-registry-cache")
 
 // NewServiceControllerCommand creates a new command that is used to start the registry service controller.
 func NewServiceControllerCommand() *cobra.Command {
@@ -43,6 +48,10 @@ func NewServiceControllerCommand() *cobra.Command {
 		SilenceErrors: true,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
+			verflag.PrintAndExitIfRequested()
+
+			log.Info("Starting registry-cache", "version", version.Get())
+
 			if err := options.optionAggregator.Complete(); err != nil {
 				return fmt.Errorf("error completing options: %w", err)
 			}
@@ -55,6 +64,7 @@ func NewServiceControllerCommand() *cobra.Command {
 		},
 	}
 
+	verflag.AddFlags(cmd.Flags())
 	options.optionAggregator.AddFlags(cmd.Flags())
 
 	return cmd

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -27,6 +27,8 @@ build:
         - pkg/webhook/operatingsystemconfig
         - vendor
         - VERSION
+      ldflags:
+      - '{{.LD_FLAGS}}'
       main: ./cmd/gardener-extension-registry-cache
 resourceSelector:
   allow:
@@ -60,6 +62,8 @@ build:
         - pkg/constants
         - vendor
         - VERSION
+      ldflags:
+      - '{{.LD_FLAGS}}'
       main: ./cmd/gardener-extension-registry-cache-admission
 deploy:
   helm:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
This PR adopts the changes from https://github.com/gardener/gardener-extension-provider-openstack/pull/426 and https://github.com/gardener/gardener-extension-provider-openstack/pull/638 to the registry-cache extension.

With the v0.2.1 images:
```
%  docker run eu.gcr.io/gardener-project/gardener/extensions/registry-cache:v0.2.1 --version=raw
# ...
{"level":"error","ts":"2023-11-13T15:48:40.902Z","msg":"Error executing the main controller command","error":"unknown flag: --version","stacktrace":"main.main\n\t/go/src/github.com/gardener/gardener-extension-registry-cache/cmd/gardener-extension-registry-cache/main.go:32\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:267"}

% docker run eu.gcr.io/gardener-project/gardener/extensions/registry-cache-admission:v0.2.1 --version=raw
version.Info{Major:"", Minor:"", GitVersion:"v0.0.0-master+$Format:%H$", GitCommit:"$Format:%H$", GitTreeState:"", BuildDate:"1970-01-01T00:00:00Z", GoVersion:"go1.21.3", Compiler:"gc", Platform:"linux/amd64"}
```

With this PR:
```
% make docker-images IMAGE=localhost/registry-cache

% docker run localhost/registry-cache:v0.3.0-dev-82f9ff6fbc632b07751021012d5109e453f7daf6 --version=raw
version.Info{Major:"0", Minor:"3+", GitVersion:"v0.3.0-dev-82f9ff6fbc632b07751021012d5109e453f7daf6-dirty", GitCommit:"82f9ff6fbc632b07751021012d5109e453f7daf6", GitTreeState:"clean", BuildDate:"2023-11-13T15:49:57+00:00", GoVersion:"go1.21.4", Compiler:"gc", Platform:"linux/amd64"}

 % docker run localhost/registry-cache-admission:v0.3.0-dev-82f9ff6fbc632b07751021012d5109e453f7daf6 --version=raw
version.Info{Major:"0", Minor:"3+", GitVersion:"v0.3.0-dev-82f9ff6fbc632b07751021012d5109e453f7daf6-dirty", GitCommit:"82f9ff6fbc632b07751021012d5109e453f7daf6", GitTreeState:"clean", BuildDate:"2023-11-13T15:49:57+00:00", GoVersion:"go1.21.4", Compiler:"gc", Platform:"linux/amd64"}
```

**Which issue(s) this PR fixes**:
Part of #3 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
