### PR TITLE
Fix exit code handling for the `hack/check-skaffold-deps.sh` script

### DIFF
--- a/hack/check-skaffold-deps.sh
+++ b/hack/check-skaffold-deps.sh
@@ -29,3 +29,7 @@ function check() {
 
 check "skaffold.yaml" "gardener-extension-registry-cache"           "extension"
 check "skaffold.yaml" "gardener-extension-registry-cache-admission" "admission"
+
+if [ "$check_successful" = false ] ; then
+  exit 1
+fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
Obviously I fail to copy-paste. Reference source: https://github.com/gardener/gardener/blob/v1.83.2/hack/check-skaffold-deps.sh
Right now the script exits with 0 even when the skaffold config is outdated.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
