### PR TITLE
force deletion e2e test: Create the Shoot with enabled extension

### DIFF
--- a/test/common/common.go
+++ b/test/common/common.go
@@ -208,7 +208,8 @@ func VerifyRegistryCache(parentCtx context.Context, log logr.Logger, shootClient
 
 		expectedImage := strings.TrimPrefix(nginxImageWithDigest, upstream+"/")
 		if _, ok := schedulerStateMap[expectedImage]; !ok {
-			return fmt.Errorf("failed to find key (image) '%s' in map (registry's scheduler-state.json file) %v", expectedImage, schedulerStateFileContent)
+			prettyFileContent, _ := json.MarshalIndent(schedulerStateMap, "", "  ")
+			return fmt.Errorf("failed to find key (image) '%s' in map (registry's scheduler-state.json file) %v", expectedImage, string(prettyFileContent))
 		}
 
 		return nil


### PR DESCRIPTION
Instead of creating the Shoot and then enabling the extension

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Create the Shoot with enabled extension instead of creating the Shoot and then enabling the extension.
This should speed up the test a little bit.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
