### PR TITLE
admission: Allow the admission Pod to resolve dns

### DIFF
--- a/charts/admission/charts/runtime/templates/deployment.yaml
+++ b/charts/admission/charts/runtime/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         checksum/secret-kubeconfig: {{ include (print $.Template.BasePath "/secret-kubeconfig.yaml") . | sha256sum }}
         {{- end }}
       labels:
+        networking.gardener.cloud/to-dns: allowed
         {{- if .Values.global.virtualGarden.enabled }}
         networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443: allowed
         {{- else }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
Currently the admission Pod does not allow configuring `secretReferenceName` because it cannot reach to DNS to perform DNS resolution for the virtual-garden-kube-apiserver Service:
```
{"level":"error","ts":"2023-12-08T07:54:14.108Z","logger":"validator.handler","msg":"Admission denied","provider":"registry-cache","kind":"Shoot","namespace":"garden-foo","name":"testy","error":"could not process: failed to get secret garden-foo/registry-secret-v1 for secretReferenceName registry-secret: failed to get API group resources: unable to retrieve the complete list of server APIs: v1: Get \"https://virtual-garden-kube-apiserver/api/v1\": dial tcp: lookup virtual-garden-kube-apiserver: i/o timeout","stacktrace":"github.com/gardener/gardener/extensions/pkg/webhook.handle\n\t/go/src/github.com/gardener/gardener-extension-registry-cache/vendor/github.com/gardener/gardener/extensions/pkg/webhook/handler.go:176\ngithub.com/gardener/gardener/extensions/pkg/webhook.(*handler).Handle\n\t/go/src/github.com/gardener/gardener-extension-registry-cache/vendor/github.com/gardener/gardener/extensions/pkg/webhook/handler.go:143\nsigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle\n\t/go/src/github.com/gardener/gardener-extension-registry-cache/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/webhook.go:169\nsigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP\n\t/go/src/github.com/gardener/gardener-extension-registry-cache/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/http.go:98\nsigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics.InstrumentedHook.InstrumentHandlerInFlight.func1\n\t/go/src/github.com/gardener/gardener-extension-registry-cache/vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_server.go:60\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2136\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1\n\t/go/src/github.com/gardener/gardener-extension-registry-cache/vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_server.go:147\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2136\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2\n\t/go/src/github.com/gardener/gardener-extension-registry-cache/vendor/github.com/prometheus/client_golang/prometheus/promhttp/instrument_server.go:109\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2136\nnet/http.(*ServeMux).ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2514\nnet/http.serverHandler.ServeHTTP\n\t/usr/local/go/src/net/http/server.go:2938\nnet/http.(*conn).serve\n\t/usr/local/go/src/net/http/server.go:2009"}
```

**Which issue(s) this PR fixes**:
See above

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
admission: An issue preventing the admission Pod to perform DNS resolutions is now fixed. Previously, the admission was denying requests when the `providerConfig.caches[].secretReferenceName` field is specified because it was not able to resolve the virtual kube-apiserver DNS name.
```
