### PR TITLE
Switch the systemd unit type from `oneshot` to `simple`

### DIFF
--- a/pkg/webhook/operatingsystemconfig/ensurer.go
+++ b/pkg/webhook/operatingsystemconfig/ensurer.go
@@ -129,8 +129,7 @@ After=containerd.service
 Requires=containerd.service
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
+Type=simple
 ExecStart=/opt/bin/configure-containerd-registries.sh ` + strings.Join(scriptArgs, " ")),
 	}
 

--- a/pkg/webhook/operatingsystemconfig/ensurer_test.go
+++ b/pkg/webhook/operatingsystemconfig/ensurer_test.go
@@ -355,8 +355,7 @@ After=containerd.service
 Requires=containerd.service
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
+Type=simple
 ExecStart=/opt/bin/configure-containerd-registries.sh ` + args),
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
@rfranzke shared that there are issues with gardener-node-agent and our `configure-containerd-registries.service` unit. GNA restarts the unit, then it times out waiting the unit to be restarted (previously CCD was using the `--no-block` flag but the systemd go library does not support it):
```
Dec 06 14:19:27 iZgw8hgv2akgch5e5qsn13Z gardener-node-agent[3208]: {"level":"error","ts":"2023-12-06T14:19:27.387Z","msg":"Reconciler error","controller":"operatingsystemconfig","namespace":"kube-system","name":"gardener-node-agent-worker-1-f76b6","reconcileID":"772eff7b-9e6f-4f91-b51e-de49778d0e92","error":"failed executing unit commands: 1 error occurred:\n\t* unable to restart unit \"configure-containerd-registries.service\": context deadline exceeded\n\n","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:227"}
```

@plkokanov found our that this is due to the type of the `configure-containerd-registries.service` unit. As described in https://trstringer.com/simple-vs-oneshot-systemd-service/, units of type `oneshot` remain in `activating` state until the `ExecStart` command succeeds. In our case, `ExecStart` waits the corresponding upstreams to be ready. The `systemctl restart configure-containerd-registries.service` command could potentially hang when there are networking issues or for some reason the registry-cache Pod does not respond to requests.
This PR switches the type of the unit to `simple`. Units of type `simple` don't block on `systemctl restart` and switch to `active` state right away.

Credits to @plkokanov.

**Which issue(s) this PR fixes**:
See above.

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The type of the `configure-containerd-registries.service` units is changed from `oneshot` to `simple`.
```
