### PR TITLE
Add monitoring dashboard for registry cache persistent volumes

### DIFF
--- a/pkg/component/registrycaches/monitoring.go
+++ b/pkg/component/registrycaches/monitoring.go
@@ -29,7 +29,7 @@ import (
 var (
 	//go:embed alerting-rules/registry-cache.rules.yaml
 	monitoringAlertingRules string
-	//go:embed monitoring/dashboard.yaml
+	//go:embed monitoring/dashboard.json
 	dashboard string
 )
 

--- a/pkg/component/registrycaches/monitoring.go
+++ b/pkg/component/registrycaches/monitoring.go
@@ -29,10 +29,16 @@ import (
 var (
 	//go:embed alerting-rules/registry-cache.rules.yaml
 	monitoringAlertingRules string
+	//go:embed monitoring/dashboard.yaml
+	dashboard string
 )
 
 func (r *registryCaches) alertingRules() string {
 	return fmt.Sprintf("registry-cache.rules.yaml: |\n  %s\n", utils.Indent(monitoringAlertingRules, 2))
+}
+
+func (r *registryCaches) dashboard() string {
+	return fmt.Sprintf("registry-cache.dashboard.json: '%s'", dashboard)
 }
 
 func (r *registryCaches) deployMonitoringConfigMap(ctx context.Context) error {
@@ -46,7 +52,8 @@ func (r *registryCaches) deployMonitoringConfigMap(ctx context.Context) error {
 		metav1.SetMetaDataLabel(&monitoringConfigMap.ObjectMeta, v1beta1constants.LabelExtensionConfiguration, v1beta1constants.LabelMonitoring)
 
 		monitoringConfigMap.Data = map[string]string{
-			v1beta1constants.PrometheusConfigMapAlertingRules: r.alertingRules(),
+			v1beta1constants.PrometheusConfigMapAlertingRules:  r.alertingRules(),
+			v1beta1constants.PlutonoConfigMapOperatorDashboard: r.dashboard(),
 		}
 
 		return nil

--- a/pkg/component/registrycaches/monitoring/dashboard.json
+++ b/pkg/component/registrycaches/monitoring/dashboard.json
@@ -249,11 +249,8 @@
   "schemaVersion": 27,
   "style": "dark",
   "tags": [
-    "image",
-    "cache",
     "registry",
-    "pull through",
-    "pull-through"
+    "cache"
   ],
   "templating": {
     "list": [
@@ -319,7 +316,7 @@
     ]
   },
   "timezone": "utc",
-  "title": "Pull-through cache registries",
+  "title": "Registry Caches",
   "uid": "extension-extension-registry-cache",
   "version": 1
 }

--- a/pkg/component/registrycaches/monitoring/dashboard.json
+++ b/pkg/component/registrycaches/monitoring/dashboard.json
@@ -18,7 +18,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1702476096107,
+  "iteration": 1702912677955,
   "links": [],
   "panels": [
     {
@@ -87,7 +87,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(label_replace(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~\"^cache-volume-registry-(${upstream_host:pipe})-0$\"}, \"upstream\", \"$1\", \"persistentvolumeclaim\", \"^cache-volume-registry-(.+)-0$\")) by (upstream)",
+          "expr": "sum by (upstream) (\n  label_replace(\n    kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~\"^cache-volume-registry-(${upstream_host:pipe})-0$\"},\n    \"upstream\",\n    \"$1\",\n    \"persistentvolumeclaim\",\n    \"^cache-volume-registry-(.+)-0$\"\n  )\n)",
           "interval": "",
           "legendFormat": "{{upstream}}",
           "refId": "A"
@@ -146,7 +146,7 @@
       "decimals": 2,
       "fieldConfig": {
         "defaults": {
-          "unit": "percentunit"
+          "unit": "decbytes"
         },
         "overrides": []
       },
@@ -192,7 +192,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(label_replace(kubelet_volume_stats_used_bytes{persistentvolumeclaim=~\"^cache-volume-registry-(${upstream_host:pipe})-0$\"}, \"upstream\", \"$1\", \"persistentvolumeclaim\", \"^cache-volume-registry-(.+)-0$\") / label_replace(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~\"^cache-volume-registry-(${upstream_host:pipe})-0$\"}, \"upstream\", \"$1\", \"persistentvolumeclaim\", \"^cache-volume-registry-(.+)-0$\")) by (upstream)",
+          "expr": "sum by (upstream) (\n  label_replace(\n    kubelet_volume_stats_available_bytes{persistentvolumeclaim=~\"^cache-volume-registry-(${upstream_host:pipe})-0$\"},\n    \"upstream\",\n    \"$1\",\n    \"persistentvolumeclaim\",\n    \"^cache-volume-registry-(.+)-0$\"\n  )\n)",
           "instant": false,
           "interval": "",
           "legendFormat": "{{upstream}}",
@@ -203,7 +203,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Persistent Volume Usage",
+      "title": "Persistent Volume Available Size",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -222,7 +222,7 @@
         {
           "$$hashKey": "object:591",
           "decimals": null,
-          "format": "percentunit",
+          "format": "decbytes",
           "label": "",
           "logBase": 1,
           "max": null,
@@ -252,20 +252,17 @@
     "image",
     "cache",
     "registry",
-    "pull through"
+    "pull through",
+    "pull-through"
   ],
   "templating": {
     "list": [
       {
         "allValue": null,
         "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": null,
         "definition": "label_values({__name__=~\"kubelet_volume_stats_.+\"}, persistentvolumeclaim)",
@@ -322,7 +319,7 @@
     ]
   },
   "timezone": "utc",
-  "title": "Image pull through cache registries",
+  "title": "Pull-through cache registries",
   "uid": "extension-extension-registry-cache",
   "version": 1
 }

--- a/pkg/component/registrycaches/monitoring/dashboard.yaml
+++ b/pkg/component/registrycaches/monitoring/dashboard.yaml
@@ -1,0 +1,328 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Plutono --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "iteration": 1702476096107,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 55,
+      "panels": [],
+      "title": "Persistent Volumes",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 59,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.26",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(label_replace(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~\"^cache-volume-registry-(${upstream_host:pipe})-0$\"}, \"upstream\", \"$1\", \"persistentvolumeclaim\", \"^cache-volume-registry-(.+)-0$\")) by (upstream)",
+          "interval": "",
+          "legendFormat": "{{upstream}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Persistent Volume Size",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transformations": [],
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:83",
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:84",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 2,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 57,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.26",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(label_replace(kubelet_volume_stats_used_bytes{persistentvolumeclaim=~\"^cache-volume-registry-(${upstream_host:pipe})-0$\"}, \"upstream\", \"$1\", \"persistentvolumeclaim\", \"^cache-volume-registry-(.+)-0$\") / label_replace(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~\"^cache-volume-registry-(${upstream_host:pipe})-0$\"}, \"upstream\", \"$1\", \"persistentvolumeclaim\", \"^cache-volume-registry-(.+)-0$\")) by (upstream)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{upstream}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Persistent Volume Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transformations": [],
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:591",
+          "decimals": null,
+          "format": "percentunit",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:592",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "image",
+    "cache",
+    "registry",
+    "pull through"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": null,
+        "definition": "label_values({__name__=~\"kubelet_volume_stats_.+\"}, persistentvolumeclaim)",
+        "description": "Pull through cache image registry",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "Registry",
+        "multi": true,
+        "name": "upstream_host",
+        "options": [],
+        "query": {
+          "query": "label_values({__name__=~\"kubelet_volume_stats_.+\"}, persistentvolumeclaim)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "^cache-volume-registry-(.+)-0$",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "hidden": false,
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "3h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "14d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "Image pull through cache registries",
+  "uid": "extension-extension-registry-cache",
+  "version": 1
+}

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -605,6 +605,7 @@ metadata:
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(monitoringConfigMap), monitoringConfigMap)).To(Succeed())
 			Expect(monitoringConfigMap.Labels).To(HaveKeyWithValue("extensions.gardener.cloud/configuration", "monitoring"))
 			Expect(monitoringConfigMap.Data).To(HaveKey("alerting_rules"))
+			Expect(monitoringConfigMap.Data).To(HaveKey("dashboard_operators"))
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Add monitoring dashboard for registry cache persistent volumes

**Which issue(s) this PR fixes**:
Part of #3

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Metrics for registry cache persistent volumes are exposed in the `Registry caches` plutono dashboard.
```
