### PR TITLE
Fix CPM for Shoot with registry-cache extension enabled

### DIFF
--- a/pkg/controller/extension/actuator.go
+++ b/pkg/controller/extension/actuator.go
@@ -174,7 +174,16 @@ func (a *actuator) Restore(ctx context.Context, log logr.Logger, ex *extensionsv
 }
 
 // Migrate the Extension resource.
-func (a *actuator) Migrate(_ context.Context, _ logr.Logger, _ *extensionsv1alpha1.Extension) error {
+func (a *actuator) Migrate(ctx context.Context, _ logr.Logger, ex *extensionsv1alpha1.Extension) error {
+	namespace := ex.GetNamespace()
+
+	registryCaches := registrycaches.New(a.client, namespace, registrycaches.Values{
+		KeepObjectsOnDestroy: true,
+	})
+	if err := component.OpDestroyAndWait(registryCaches).Destroy(ctx); err != nil {
+		return fmt.Errorf("failed to destroy the registry caches component: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
Currently a CPM for a Shoot with registry-cache extension enabled fails during the migrate phase with:
```
task "Waiting until shoot managed resources have been deleted" failed: retry failed with context deadline exceeded, last error: retry failed with context deadline exceeded, last error: error while waiting for all shoot managed resources to be deleted: : 1 error occurred: shoot managed resource shoot--foo--bar/extension-registry-cache still exists
```

Right now in https://github.com/gardener/gardener/blob/628d9395e29f2fa285b5d825674ca3d8f5310fcc/pkg/gardenlet/controller/shoot/shoot/reconciler_migrate.go#L163-L168, gardenlet is taking care only for MRs with `origin=gardener`. Our MR is with `origin=registry-cache` and we need to take care of it during the migrate phase.

**Which issue(s) this PR fixes**:
Part of #3

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing control plane migration for a Shoot with registry-cache extension enabled to fail is now fixed.
```
