### PR TITLE
Fix the testmachinery test for arm64 Shoots

### DIFF
--- a/test/common/common.go
+++ b/test/common/common.go
@@ -39,12 +39,12 @@ import (
 )
 
 const (
-	// DockerNginx1130ImageWithDigest corresponds to the nginx:1.13.0 image.
-	DockerNginx1130ImageWithDigest = "docker.io/library/nginx@sha256:12d30ce421ad530494d588f87b2328ddc3cae666e77ea1ae5ac3a6661e52cde6"
-	// DockerNginx1140ImageWithDigest corresponds to the nginx:1.14.0 image.
-	DockerNginx1140ImageWithDigest = "docker.io/library/nginx@sha256:8b600a4d029481cc5b459f1380b30ff6cb98e27544fc02370de836e397e34030"
-	// DockerNginx1150ImageWithDigest corresponds to the nginx:1.15.0 image.
-	DockerNginx1150ImageWithDigest = "docker.io/library/nginx@sha256:62a095e5da5f977b9f830adaf64d604c614024bf239d21068e4ca826d0d629a4"
+	// DockerNginx1230ImageWithDigest corresponds to the nginx:1.23.0 image.
+	DockerNginx1230ImageWithDigest = "docker.io/library/nginx@sha256:db345982a2f2a4257c6f699a499feb1d79451a1305e8022f16456ddc3ad6b94c"
+	// DockerNginx1240ImageWithDigest corresponds to the nginx:1.24.0 image.
+	DockerNginx1240ImageWithDigest = "docker.io/library/nginx@sha256:066476749f229923b9de29cc9a0738ea2d45923b16a2b388449ea549673f97d8"
+	// DockerNginx1250ImageWithDigest corresponds to the nginx:1.25.0 image.
+	DockerNginx1250ImageWithDigest = "docker.io/library/nginx@sha256:b997b0db9c2bc0a2fb803ced5fb9ff3a757e54903a28ada3e50412cc3ab7822f"
 
 	// ArtifactRegistryNginx1176ImageWithDigest corresponds to the europe-docker.pkg.dev/gardener-project/releases/3rd/nginx:1.17.6 image (copy of docker.io/library/nginx:1.17.6).
 	ArtifactRegistryNginx1176ImageWithDigest = "europe-docker.pkg.dev/gardener-project/releases/3rd/nginx@sha256:b2d89d0a210398b4d1120b3e3a7672c16a4ba09c2c4a0395f18b9f7999b768f2"

--- a/test/e2e/create_enable_add_remove_disable_delete_test.go
+++ b/test/e2e/create_enable_add_remove_disable_delete_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Registry Cache Extension Tests", func() {
 		common.WaitUntilRegistryConfigurationsAreApplied(ctx, f.Logger, f.ShootFramework.ShootClient)
 
 		By("[docker.io] Verify registry-cache works")
-		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootFramework.ShootClient, "docker.io", common.DockerNginx1130ImageWithDigest)
+		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootFramework.ShootClient, "docker.io", common.DockerNginx1230ImageWithDigest)
 
 		By("Add the public.ecr.aws upstream to the registry-cache extension")
 		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)

--- a/test/e2e/create_enabled_force_delete_test.go
+++ b/test/e2e/create_enabled_force_delete_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Registry Cache Extension Tests", func() {
 		common.WaitUntilRegistryConfigurationsAreApplied(ctx, f.Logger, f.ShootFramework.ShootClient)
 
 		By("Verify registry-cache works")
-		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootFramework.ShootClient, "docker.io", common.DockerNginx1130ImageWithDigest)
+		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootFramework.ShootClient, "docker.io", common.DockerNginx1230ImageWithDigest)
 
 		By("Force Delete Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)

--- a/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
+++ b/test/e2e/create_enabled_hibernate_reconcile_delete_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Registry Cache Extension Tests", func() {
 		common.WaitUntilRegistryConfigurationsAreApplied(ctx, f.Logger, f.ShootFramework.ShootClient)
 
 		By("Verify registry-cache works")
-		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootFramework.ShootClient, "docker.io", common.DockerNginx1130ImageWithDigest)
+		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootFramework.ShootClient, "docker.io", common.DockerNginx1230ImageWithDigest)
 
 		By("Hibernate Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Shoot registry cache testing", func() {
 		common.WaitUntilRegistryConfigurationsAreApplied(ctx, f.Logger, f.ShootClient)
 
 		By("Verify registry-cache works")
-		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootClient, "docker.io", common.DockerNginx1130ImageWithDigest)
+		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootClient, "docker.io", common.DockerNginx1230ImageWithDigest)
 
 		By("Disable the registry-cache extension")
 		Expect(f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -62,9 +62,9 @@ var _ = Describe("Shoot registry cache testing", func() {
 		common.WaitUntilRegistryConfigurationsAreApplied(ctx, f.Logger, f.ShootClient)
 
 		By("Verify registry-cache works")
-		// We are using nginx:1.14.0 as nginx:1.13.0 is already used by the "should enable and disable the registry-cache extension" test.
-		// Hence, nginx:1.13.0 will be present in the Node.
-		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootClient, "docker.io", common.DockerNginx1140ImageWithDigest)
+		// We are using nginx:1.24.0 as nginx:1.23.0 is already used by the "should enable and disable the registry-cache extension" test.
+		// Hence, nginx:1.23.0 will be present in the Node.
+		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootClient, "docker.io", common.DockerNginx1240ImageWithDigest)
 
 		By("Hibernate Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
@@ -92,8 +92,8 @@ var _ = Describe("Shoot registry cache testing", func() {
 		common.WaitUntilRegistryConfigurationsAreApplied(ctx, f.Logger, f.ShootClient)
 
 		By("Verify registry-cache works after wake up")
-		// We are using nginx:1.15.0 as nginx:1.14.0 is already used above and already present in the Node and in the registry cache.
-		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootClient, "docker.io", common.DockerNginx1150ImageWithDigest)
+		// We are using nginx:1.25.0 as nginx:1.24.0 is already used above and already present in the Node and in the registry cache.
+		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootClient, "docker.io", common.DockerNginx1250ImageWithDigest)
 	}, hibernationTestTimeout, framework.WithCAfterTest(func(ctx context.Context) {
 		if v1beta1helper.HibernationIsEnabled(f.Shoot) {
 			By("Wake up Shoot")


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
The tests use `nginx:1.13.0` which is not a multi-arch image. 
The test execution against arm64 Shoots fails with:
```
  In [It] at: /src/test/testmachinery/shoot/enable_disable_test.go:58 @ 12/20/23 07:30:11.546
      }
         },
              s: "pod \"default/nginx-wfwb9\" is not ready: <nil>",
          err: <*errors.errorString | 0xc000d3e4a0>{
          ctxError: <context.deadlineExceededError>{},
      {
      retry failed with context deadline exceeded, last error: pod "default/nginx-wfwb9" is not ready: <nil>
      <*retry.Error | 0xc0008188c0>: 
  [FAILED] Expected success, but got an error:

/src/vendor/github.com/gardener/gardener/test/framework/gingko_utils.go:26
Shoot registry cache testing  [It] [BETA] [SERIAL] [SHOOT] should enable and disable the registry-cache extension
```

This change bumps the nginx images as they new versions are multi-arch.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
An issue causing the testmachinery test to fail against an arm64 Shoot is now resolved.
```
