### PR TITLE
Deflake `should enable and disable the registry-cache extension` TM test

### DIFF
--- a/.test-defs/TestSuiteRegistryCacheBetaSerial.yaml
+++ b/.test-defs/TestSuiteRegistryCacheBetaSerial.yaml
@@ -6,7 +6,7 @@ spec:
   owner: gardener-oq@listserv.sap.com
   description: registry-cache extension test suite that includes all serial beta tests
 
-  activeDeadlineSeconds: 7200
+  activeDeadlineSeconds: 9000
   labels: ["shoot", "beta"]
   behavior:
   - serial

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	defaultTestTimeout        = 30 * time.Minute
+	defaultTestTimeout        = 40 * time.Minute
 	defaultTestCleanupTimeout = 10 * time.Minute
 )
 
@@ -63,6 +63,8 @@ var _ = Describe("Shoot registry cache testing", func() {
 		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootClient, "docker.io", common.DockerNginx1230ImageWithDigest)
 
 		By("Disable the registry-cache extension")
+		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
+		defer cancel()
 		Expect(f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
 			common.RemoveRegistryCacheExtension(shoot)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
I see many failures in the `should enable and disable the registry-cache extension` TM test.
The reason for the failures is that in the step `Disable the registry-cache extension`
https://github.com/gardener/gardener-extension-registry-cache/blob/8a088c8b75e928e8a6c79954d3f588c6c8a60f9a/test/testmachinery/shoot/enable_disable_test.go#L65-L70

`ctx` is used. However `ctx` is already a context of another step `Wait until the registry configuration is applied`: https://github.com/gardener/gardener-extension-registry-cache/blob/5ec3e79bbd15d3e137027e83ab31cad90c96d117/test/testmachinery/shoot/enable_disable_test.go#L57-L60

After step `Wait until the registry configuration is applied` the step `Verify registry-cache works` is executed (can take up to 12mins) and currently the step `Disable the registry-cache extension` is executed with context that has less than 5min timeout (it can be the case that the timeout is already exceeded meanwhile during the next step execution).

This PR fixes this by creating a new context from the parentContext with timeout of 10mins for the `Disable the registry-cache extension` step.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A flake in the `should enable and disable the registry-cache extension` testmachinery test is now fixed.
```
