### PR TITLE
Mitigate distribution/distribution#4191 by disabling blobdescriptor cache

### DIFF
--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -142,8 +142,10 @@ log:
 storage:
   delete:
     enabled: ` + strconv.FormatBool(garbageCollectionEnabled) + `
-  cache:
-    blobdescriptor: inmemory
+  # Mitigate https://github.com/distribution/distribution/issues/2367 by disabling the blobdescriptor cache.
+  # For more details, see https://github.com/distribution/distribution/issues/2367#issuecomment-1874449361.
+  # cache:
+  #  blobdescriptor: inmemory
   filesystem:
     rootdirectory: /var/lib/registry
 http:
@@ -438,7 +440,7 @@ metadata:
 				Expect(managedResourceSecret.Labels["resources.gardener.cloud/garbage-collectable-reference"]).To(Equal("true"))
 
 				Expect(managedResourceSecret.Data).To(HaveLen(8))
-				dockerConfigSecretName := "registry-docker-io-config-8e4f5227"
+				dockerConfigSecretName := "registry-docker-io-config-e2bc0812"
 				dockerConfigSecret := configSecretYAMLFor(dockerConfigSecretName, "registry-docker-io", "docker.io", configYAMLFor("https://registry-1.docker.io", true, "", ""))
 				Expect(string(managedResourceSecret.Data["secret__kube-system__"+dockerConfigSecretName+".yaml"])).To(Equal(dockerConfigSecret))
 				Expect(string(managedResourceSecret.Data["service__kube-system__registry-docker-io.yaml"])).To(Equal(serviceYAMLFor("registry-docker-io", "docker.io")))
@@ -446,7 +448,7 @@ metadata:
 				Expect(string(managedResourceSecret.Data["statefulset__kube-system__registry-docker-io.yaml"])).To(Equal(dockerStatefulSet))
 				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__kube-system__registry-docker-io.yaml"])).To(Equal(vpaYAMLFor("registry-docker-io")))
 
-				arConfigSecretName := "registry-europe-docker-pkg-dev-config-7442b8d7"
+				arConfigSecretName := "registry-europe-docker-pkg-dev-config-c8fad413"
 				arConfigSecret := configSecretYAMLFor(arConfigSecretName, "registry-europe-docker-pkg-dev", "europe-docker.pkg.dev", configYAMLFor("https://europe-docker.pkg.dev", false, "", ""))
 				Expect(string(managedResourceSecret.Data["secret__kube-system__"+arConfigSecretName+".yaml"])).To(Equal(arConfigSecret))
 				Expect(string(managedResourceSecret.Data["service__kube-system__registry-europe-docker-pkg-dev.yaml"])).To(Equal(serviceYAMLFor("registry-europe-docker-pkg-dev", "europe-docker.pkg.dev")))
@@ -491,10 +493,10 @@ metadata:
 				Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_registry-cache.yaml"])).To(Equal(clusterRolePSPYAML))
 				Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_registry-cache.yaml"])).To(Equal(roleBindingPSPYAML))
 
-				dockerConfigSecretName := "registry-docker-io-config-8e4f5227"
+				dockerConfigSecretName := "registry-docker-io-config-e2bc0812"
 				dockerStatefulSet := statefulSetYAMLFor("registry-docker-io", "docker.io", "https://registry-1.docker.io", "10Gi", dockerConfigSecretName, "registry-cache", nil)
 				Expect(string(managedResourceSecret.Data["statefulset__kube-system__registry-docker-io.yaml"])).To(Equal(dockerStatefulSet))
-				arConfigSecretName := "registry-europe-docker-pkg-dev-config-7442b8d7"
+				arConfigSecretName := "registry-europe-docker-pkg-dev-config-c8fad413"
 				arStatefulSet := statefulSetYAMLFor("registry-europe-docker-pkg-dev", "europe-docker.pkg.dev", "https://europe-docker.pkg.dev", "20Gi", arConfigSecretName, "registry-cache", pointer.String("premium"))
 				Expect(string(managedResourceSecret.Data["statefulset__kube-system__registry-europe-docker-pkg-dev.yaml"])).To(Equal(arStatefulSet))
 			})
@@ -552,7 +554,7 @@ metadata:
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
 
 				Expect(managedResourceSecret.Data).To(HaveLen(8))
-				dockerConfigSecretName := "registry-docker-io-config-5e321f59"
+				dockerConfigSecretName := "registry-docker-io-config-fc0731b8"
 				dockerConfigSecret := configSecretYAMLFor(dockerConfigSecretName, "registry-docker-io", "docker.io", configYAMLFor("https://registry-1.docker.io", true, "docker-user", "s3cret"))
 				Expect(string(managedResourceSecret.Data["secret__kube-system__"+dockerConfigSecretName+".yaml"])).To(Equal(dockerConfigSecret))
 				Expect(string(managedResourceSecret.Data["service__kube-system__registry-docker-io.yaml"])).To(Equal(serviceYAMLFor("registry-docker-io", "docker.io")))
@@ -560,7 +562,7 @@ metadata:
 				Expect(string(managedResourceSecret.Data["statefulset__kube-system__registry-docker-io.yaml"])).To(Equal(dockerStatefulSet))
 				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__kube-system__registry-docker-io.yaml"])).To(Equal(vpaYAMLFor("registry-docker-io")))
 
-				arConfigSecretName := "registry-europe-docker-pkg-dev-config-3feda12b"
+				arConfigSecretName := "registry-europe-docker-pkg-dev-config-17b7acfe"
 				arConfigSecret := configSecretYAMLFor(arConfigSecretName, "registry-europe-docker-pkg-dev", "europe-docker.pkg.dev", configYAMLFor("https://europe-docker.pkg.dev", false, "ar-user", `{"foo":"bar"}`))
 				Expect(string(managedResourceSecret.Data["secret__kube-system__"+arConfigSecretName+".yaml"])).To(Equal(arConfigSecret))
 				Expect(string(managedResourceSecret.Data["service__kube-system__registry-europe-docker-pkg-dev.yaml"])).To(Equal(serviceYAMLFor("registry-europe-docker-pkg-dev", "europe-docker.pkg.dev")))

--- a/pkg/component/registrycaches/templates/config.yml.tpl
+++ b/pkg/component/registrycaches/templates/config.yml.tpl
@@ -6,8 +6,10 @@ log:
 storage:
   delete:
     enabled: {{ .storage_delete_enabled }}
-  cache:
-    blobdescriptor: inmemory
+  # Mitigate https://github.com/distribution/distribution/issues/2367 by disabling the blobdescriptor cache.
+  # For more details, see https://github.com/distribution/distribution/issues/2367#issuecomment-1874449361.
+  # cache:
+  #  blobdescriptor: inmemory
   filesystem:
     rootdirectory: /var/lib/registry
 http:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
We have occurrences of https://github.com/distribution/distribution/issues/4191 (duplicate of https://github.com/distribution/distribution/issues/2367) in our environments. The issue can be mitigated by disabling the blobdescriptor cache. See https://github.com/distribution/distribution/issues/2367#issuecomment-1874449361.

**Which issue(s) this PR fixes**:
Part of #3 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An issue in the [Distribution project](https://github.com/distribution/distribution/) that causes in-used blob to be wrongly deleted during GC of an image layer which later on causes the images that reference this blob to fail to be pulled is now mitigated.
```
