### PR TITLE
Fix StatefulSet Pod creation for caches with a long upstream

### DIFF
--- a/pkg/component/registrycaches/export_test.go
+++ b/pkg/component/registrycaches/export_test.go
@@ -14,4 +14,4 @@
 
 package registrycaches
 
-var ComputeStatefulSetName = computeStatefulSetName
+var ComputeName = computeName

--- a/pkg/component/registrycaches/export_test.go
+++ b/pkg/component/registrycaches/export_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registrycaches
+
+var ComputeStatefulSetName = computeStatefulSetName

--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -276,7 +276,7 @@ func (r *registryCaches) computeResourcesDataForRegistryCache(ctx context.Contex
 	)
 
 	var (
-		name         = computeStatefulSetName(cache.Upstream)
+		name         = computeName(cache.Upstream)
 		configValues = map[string]interface{}{
 			"http_addr":              fmt.Sprintf(":%d", constants.RegistryCachePort),
 			"http_debug_addr":        fmt.Sprintf(":%d", debugPort),
@@ -514,11 +514,13 @@ func getLabels(name, upstream string) map[string]string {
 	}
 }
 
-// computeStatefulSetName returns StatulSet name by given upstream.
+// computeName computes a name by given upstream.
+// The name later on is used by the registry cache Service, config Secret, StatefulSet and VPA.
+//
 // If length of registry-<escaped_upsteam> is NOT > 52, the name is registry-<escaped_upsteam>.
 // Otherwise it is registry-<truncated_escaped_upsteam>-<hash> where <escaped_upsteam> is truncated at 37 chars.
 // The returned name is at most 52 chars.
-func computeStatefulSetName(upstream string) string {
+func computeName(upstream string) string {
 	// The StatefulSet name limit is 63 chars. However Pods for a StatefulSet with name > 52 chars cannot be created due to https://github.com/kubernetes/kubernetes/issues/64023.
 	// The "controller-revision-hash" label gets added to the StatefulSet Pod. The label value is in format <stateful_set_name>_<hash> where <hash> is 10 or 11 chars.
 	// A label value limit is 63 chars. That's why a Pod for a StatefulSet with name > 52 chars cannot be created.

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -708,9 +708,9 @@ metadata:
 		})
 	})
 
-	DescribeTable("#computeStatefulSetName",
+	DescribeTable("#computeName",
 		func(upstream, expected string) {
-			actual := ComputeStatefulSetName(upstream)
+			actual := ComputeName(upstream)
 			Expect(len(actual)).NotTo(BeNumerically(">", 52))
 			Expect(actual).To(Equal(expected))
 		},

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -707,6 +707,17 @@ metadata:
 			})
 		})
 	})
+
+	DescribeTable("#computeStatefulSetName",
+		func(upstream, expected string) {
+			actual := ComputeStatefulSetName(upstream)
+			Expect(len(actual)).NotTo(BeNumerically(">", 52))
+			Expect(actual).To(Equal(expected))
+		},
+
+		Entry("short upstream", "docker.io", "registry-docker-io"),
+		Entry("long upstream", "myproj-releases.common.repositories.cloud.com", "registry-myproj-releases-common-repositories-c-3f834"),
+	)
 })
 
 func encodeBase64(val string) string {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
The reason for #120 is https://github.com/kubernetes/kubernetes/issues/64023. Long story short the explanation is:
```golang
	// The StatefulSet name limit is 63 chars. However Pods for a StatefulSet with name > 52 chars cannot be created due to https://github.com/kubernetes/kubernetes/issues/64023.
	// The "controller-revision-hash" label gets added to the StatefulSet Pod. The label value is in format <stateful_set_name>_<hash> where <hash> is 10 or 11 chars.
```

With this PR we mitigate the upstream issue by NOT exceeding 52 chars for StatefulSet names. This change should be backwards-compatible.

**Which issue(s) this PR fixes**:
Fixes #120

**Special notes for your reviewer**:
For completeness, these are some size limits in K8s:
- StatefulSet name length - 63, https://github.com/kubernetes/kubernetes/blob/a714e9e4855f93053206555f5810f6942acb7a8d/pkg/apis/apps/validation/validation.go#L39-L44
- Pod name length - 253, https://github.com/kubernetes/kubernetes/blob/703edddae4e3d5bb655742afffc0a757103a2526/pkg/apis/core/validation/validation.go#L244
- Pod label value length - 63, https://github.com/kubernetes/kubernetes/blob/703edddae4e3d5bb655742afffc0a757103a2526/pkg/apis/core/validation/validation.go#L244
- Secret name length - 253, https://github.com/kubernetes/kubernetes/blob/703edddae4e3d5bb655742afffc0a757103a2526/pkg/apis/core/validation/validation.go#L281
- PVC name length - 253, https://github.com/kubernetes/kubernetes/blob/703edddae4e3d5bb655742afffc0a757103a2526/pkg/apis/core/validation/validation.go#L1661

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing the registry StatefulSet to fail to create Pods for registry caches with long upstreams is now mitigated.
```
