### PR TITLE
Improve the validation for a cache upstream

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -65,8 +65,8 @@ The `providerConfig` field is required.
 
 The `providerConfig.caches` field contains information about the registry caches to deploy. It is a required field. At least one cache has to be specified.
 
-The `providerConfig.caches[].upstream` field is the remote registry host (and optionally port) to cache. It is a required field.
-The desired format is `host[:port]`. The value must not include a scheme. The configured upstream registry must be accessible by `https` (`https://` is the assumed scheme).
+The `providerConfig.caches[].upstream` field is the remote registry host to cache. It is a required field.
+The value must be a valid DNS subdomain (RFC 1123). It must not include a scheme or port. The configured upstream registry must be accessible by `https` (`https://` is the assumed scheme).
 
 The `providerConfig.caches[].volume` field contains settings for the registry cache volume.
 The registry-cache extension deploys a StatefulSet with a volume claim template. A PersistentVolumeClaim is created with the configured size and StorageClass name.

--- a/hack/api-reference/registry.md
+++ b/hack/api-reference/registry.md
@@ -65,7 +65,8 @@ string
 </em>
 </td>
 <td>
-<p>Upstream is the remote registry host (and optionally port) to cache.</p>
+<p>Upstream is the remote registry host to cache.
+The value must be a valid DNS subdomain (RFC 1123).</p>
 </td>
 </tr>
 <tr>
@@ -136,7 +137,7 @@ string
 </em>
 </td>
 <td>
-<p>Upstream is the remote registry host (and optionally port).</p>
+<p>Upstream is the remote registry host.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -163,9 +163,9 @@ var _ = Describe("Shoot validator", func() {
 
 				err := shootValidator.Validate(ctx, shoot, nil)
 				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("spec.extensions[0].providerConfig.caches[0].upstream"),
-					"Detail": ContainSubstring("upstream must not include a scheme"),
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("spec.extensions[0].providerConfig.caches[0].upstream"),
+					"BadValue": Equal("https://registry.example.com"),
 				}))))
 			})
 

--- a/pkg/apis/registry/v1alpha1/types.go
+++ b/pkg/apis/registry/v1alpha1/types.go
@@ -31,7 +31,8 @@ type RegistryConfig struct {
 
 // RegistryCache represents a registry cache to deploy.
 type RegistryCache struct {
-	// Upstream is the remote registry host (and optionally port) to cache.
+	// Upstream is the remote registry host to cache.
+	// The value must be a valid DNS subdomain (RFC 1123).
 	Upstream string `json:"upstream"`
 	// Size is the size of the registry cache.
 	// Defaults to 10Gi.
@@ -65,7 +66,7 @@ type RegistryStatus struct {
 
 // RegistryCacheStatus represents a deployed registry cache.
 type RegistryCacheStatus struct {
-	// Upstream is the remote registry host (and optionally port).
+	// Upstream is the remote registry host.
 	Upstream string `json:"upstream"`
 	// Endpoint is the registry cache endpoint.
 	// Example: "http://10.4.246.205:5000"

--- a/pkg/apis/registry/v1alpha2/types.go
+++ b/pkg/apis/registry/v1alpha2/types.go
@@ -31,7 +31,8 @@ type RegistryConfig struct {
 
 // RegistryCache represents a registry cache to deploy.
 type RegistryCache struct {
-	// Upstream is the remote registry host (and optionally port) to cache.
+	// Upstream is the remote registry host to cache.
+	// The value must be a valid DNS subdomain (RFC 1123).
 	Upstream string `json:"upstream"`
 	// Volume contains settings for the registry cache volume.
 	// +optional
@@ -76,7 +77,7 @@ type RegistryStatus struct {
 
 // RegistryCacheStatus represents a deployed registry cache.
 type RegistryCacheStatus struct {
-	// Upstream is the remote registry host (and optionally port).
+	// Upstream is the remote registry host.
 	Upstream string `json:"upstream"`
 	// Endpoint is the registry cache endpoint.
 	// Example: "http://10.4.246.205:5000"

--- a/pkg/apis/registry/validation/validation.go
+++ b/pkg/apis/registry/validation/validation.go
@@ -16,13 +16,13 @@ package validation
 
 import (
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry"
@@ -85,18 +85,12 @@ func validateRegistryCache(cache registry.RegistryCache, fldPath *field.Path) fi
 }
 
 func validateUpstream(fldPath *field.Path, upstream string) field.ErrorList {
-	var allErrors field.ErrorList
-
-	const form = "; desired format: host[:port]"
-	if len(upstream) == 0 {
-		allErrors = append(allErrors, field.Required(fldPath, "upstream must be provided"+form))
+	var allErrs field.ErrorList
+	for _, msg := range validation.IsDNS1123Subdomain(upstream) {
+		allErrs = append(allErrs, field.Invalid(fldPath, upstream, msg))
 	}
 
-	if strings.HasPrefix(upstream, "https://") || strings.HasPrefix(upstream, "http://") {
-		allErrors = append(allErrors, field.Invalid(fldPath, upstream, "upstream must not include a scheme"+form))
-	}
-
-	return allErrors
+	return allErrs
 }
 
 // validatePositiveQuantity validates that a Quantity is positive.

--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -276,7 +276,7 @@ func (r *registryCaches) computeResourcesDataForRegistryCache(ctx context.Contex
 	)
 
 	var (
-		name         = strings.Replace(fmt.Sprintf("registry-%s", strings.Split(cache.Upstream, ":")[0]), ".", "-", -1)
+		name         = strings.Replace(fmt.Sprintf("registry-%s", cache.Upstream), ".", "-", -1)
 		configValues = map[string]interface{}{
 			"http_addr":              fmt.Sprintf(":%d", constants.RegistryCachePort),
 			"http_debug_addr":        fmt.Sprintf(":%d", debugPort),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
While working on https://github.com/gardener/gardener-extension-registry-cache/pull/129 I noticed that we actually don't support upstreams with ports but our docs state that it is supported.
A Shoot reconciliation with a cache with upstream with a port (for example `public.ecr.aws:443`) fails with:
```
v1/Secret/kube-system/registry-public-ecr-aws-config-3cfbb538\": Secret \"registry-public-ecr-aws-config-3cfbb538\" is invalid: metadata.labels: Invalid value: \"public.ecr.aws:443\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'
```

The above message is for Secret but the same label with the same value gets added to all resources, incl. the StatefulSet. Hence, upstream with port was not working since the initial implementation.

This PR improves the validation for the cache upstream (requires to be a valid DNS subdomain (RFC 1123)) and properly updates docs so that it is clear that upstream with port is not supported.

**Which issue(s) this PR fixes**:
Part of #3

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The cache upstream is now required to be a a valid DNS subdomain (RFC 1123).
```
