### PR TITLE
Forbid GC enablement once it is disabled

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -87,6 +87,7 @@ The `providerConfig.caches[].secretReferenceName` is the name of the reference f
 
 When the registry cache receives a request for an image that is not present in its local store, it fetches the image from the upstream, returns it to the client and stores the image in the local store. The registry cache runs a scheduler that deletes images when their time to live (ttl) expires. When adding an image to the local store, the registry cache also adds a time to live for the image. The ttl value is `7d`. Requesting an image from the registry cache does not extend the time to live of the image. Hence, an image is always garbage collected from the registry cache store after `7d`.
 At the time of writing this document, there is no functionality for garbage collection based on disk size - e.g. garbage collecting images when a certain disk usage threshold is passed.
+The garbage collection cannot be enabled once it is disabled. This constraint is added to mitigate [distribution/distribution#4249](https://github.com/distribution/distribution/issues/4249).
 
 ## Increase the cache disk size
 

--- a/pkg/apis/registry/validation/validation_test.go
+++ b/pkg/apis/registry/validation/validation_test.go
@@ -194,10 +194,26 @@ var _ = Describe("Validation", func() {
 				})),
 			))
 		})
+
+		It("should deny garbage collection enablement once it is disabled", func() {
+			oldRegistryConfig.Caches[0].GarbageCollection = &api.GarbageCollection{
+				Enabled: false,
+			}
+			registryConfig.Caches[0].GarbageCollection = &api.GarbageCollection{
+				Enabled: true,
+			}
+
+			Expect(ValidateRegistryConfigUpdate(oldRegistryConfig, registryConfig, fldPath)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("providerConfig.caches[0].garbageCollection.enabled"),
+					"Detail": Equal("garbage collection cannot be enabled once it is disabled"),
+				})),
+			))
+		})
 	})
 
 	Describe("#ValidateUpstreamRegistrySecret", func() {
-
 		var secret *corev1.Secret
 
 		BeforeEach(func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
While looking into the GC in the Distribution project I noticed https://github.com/distribution/distribution/issues/4249. Long story short, once you enable GC for a cache with disabled GC, images that were pulled before `7d` in the cache with disabled GC will never be GC-ed. This can be confusing for users as usually the expectation would be that once GC is enabled, all images to get GC-ed after the TTL (`7d`) is expired.

**Which issue(s) this PR fixes**:
Part of #3

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
It is now forbidden to enable garbage collection for a cache once it is disabled. This constraint is added to mitigate [distribution/distribution#4249](https://github.com/distribution/distribution/issues/4249).
```
