### PR TITLE
Improve `configure-containerd-registries` retry strategy

### DIFF
--- a/pkg/webhook/operatingsystemconfig/scripts/configure-containerd-registries.sh
+++ b/pkg/webhook/operatingsystemconfig/scripts/configure-containerd-registries.sh
@@ -10,13 +10,14 @@ function with_backoff {
     exit 1
   fi
 
-  local max_attempts=${MAX_ATTEMPTS-20}
-  local interval=${INTERVAL-1}
-  local max_interval=1024
+  local max_attempts=${MAX_ATTEMPTS-60}
+  local linear_duration=${LINEAR_DURATION-150}
+  local interval=${INTERVAL-3}
+  local max_interval=192
   local attempt=1
   local exit_code=0
 
-  while (( attempt < max_attempts ))
+  while (( attempt <= max_attempts ))
   do
     if "$@"
     then
@@ -28,10 +29,11 @@ function with_backoff {
     echo "[$run_id] Request failed! Retrying in $interval seconds..."
     sleep "$interval"
 
-    attempt=$(( attempt + 1 ))
-    if (( interval * 2 <= max_interval )); then
+    if (( attempt * (interval + 2) >= linear_duration && interval * 2 <= max_interval )); then
       interval=$(( interval * 2 ))
     fi
+    attempt=$(( attempt + 1 ))
+
   done
 
   if [[ $exit_code != 0 ]]


### PR DESCRIPTION
- start with linear retries with 3 sec delay for the first 150 sec
- continue with exponential backoff

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
The `configure-containerd-registries` unit configures `containerd` to use registries mirrors once they are accessible from the Node. To do this, it queries registries mirrors until they become available.
With this PR, the retry strategy for querying registries is improved so that the `containerd` configuration is set as early as possible:
- start with linear retries with 3 sec delay for the first 150 sec
- continue with exponential backoff

**Which issue(s) this PR fixes**:
Part of #3

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
