### PR TITLE
Clean up v1alpha1 usages from tests

### DIFF
--- a/pkg/admission/validator/cache/shoot_test.go
+++ b/pkg/admission/validator/cache/shoot_test.go
@@ -39,7 +39,7 @@ import (
 
 	"github.com/gardener/gardener-extension-registry-cache/pkg/admission/validator/cache"
 	api "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry"
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha1"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
 )
 
 func TestRegistryCacheValidator(t *testing.T) {
@@ -64,7 +64,7 @@ var _ = Describe("Shoot validator", func() {
 		BeforeEach(func() {
 			scheme := runtime.NewScheme()
 			Expect(api.AddToScheme(scheme)).To(Succeed())
-			Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
 
 			decoder := serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder()
 			ctrl = gomock.NewController(GinkgoT())
@@ -82,15 +82,17 @@ var _ = Describe("Shoot validator", func() {
 						{
 							Type: "registry-cache",
 							ProviderConfig: &runtime.RawExtension{
-								Raw: encode(&v1alpha1.RegistryConfig{
+								Raw: encode(&v1alpha2.RegistryConfig{
 									TypeMeta: metav1.TypeMeta{
-										APIVersion: v1alpha1.SchemeGroupVersion.String(),
+										APIVersion: v1alpha2.SchemeGroupVersion.String(),
 										Kind:       "RegistryConfig",
 									},
-									Caches: []v1alpha1.RegistryCache{
+									Caches: []v1alpha2.RegistryCache{
 										{
 											Upstream: "docker.io",
-											Size:     &size,
+											Volume: &v1alpha2.Volume{
+												Size: &size,
+											},
 										},
 									},
 								}),
@@ -154,12 +156,12 @@ var _ = Describe("Shoot validator", func() {
 
 			It("should return err when registry-cache providerConfig is invalid", func() {
 				shoot.Spec.Extensions[0].ProviderConfig = &runtime.RawExtension{
-					Raw: encode(&v1alpha1.RegistryConfig{
+					Raw: encode(&v1alpha2.RegistryConfig{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: v1alpha1.SchemeGroupVersion.String(),
+							APIVersion: v1alpha2.SchemeGroupVersion.String(),
 							Kind:       "RegistryConfig",
 						},
-						Caches: []v1alpha1.RegistryCache{
+						Caches: []v1alpha2.RegistryCache{
 							{
 								Upstream: "https://registry.example.com",
 							},
@@ -211,15 +213,17 @@ var _ = Describe("Shoot validator", func() {
 			It("should return err when registry-cache providerConfig update is invalid", func() {
 				newSize := resource.MustParse("42Gi")
 				shoot.Spec.Extensions[0].ProviderConfig = &runtime.RawExtension{
-					Raw: encode(&v1alpha1.RegistryConfig{
+					Raw: encode(&v1alpha2.RegistryConfig{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: v1alpha1.SchemeGroupVersion.String(),
+							APIVersion: v1alpha2.SchemeGroupVersion.String(),
 							Kind:       "RegistryConfig",
 						},
-						Caches: []v1alpha1.RegistryCache{
+						Caches: []v1alpha2.RegistryCache{
 							{
 								Upstream: "docker.io",
-								Size:     &newSize,
+								Volume: &v1alpha2.Volume{
+									Size: &newSize,
+								},
 							},
 						},
 					}),
@@ -264,15 +268,17 @@ var _ = Describe("Shoot validator", func() {
 					},
 				}
 				shoot.Spec.Extensions[0].ProviderConfig = &runtime.RawExtension{
-					Raw: encode(&v1alpha1.RegistryConfig{
+					Raw: encode(&v1alpha2.RegistryConfig{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: v1alpha1.SchemeGroupVersion.String(),
+							APIVersion: v1alpha2.SchemeGroupVersion.String(),
 							Kind:       "RegistryConfig",
 						},
-						Caches: []v1alpha1.RegistryCache{
+						Caches: []v1alpha2.RegistryCache{
 							{
-								Upstream:            "docker.io",
-								Size:                &size,
+								Upstream: "docker.io",
+								Volume: &v1alpha2.Volume{
+									Size: &size,
+								},
 								SecretReferenceName: pointer.String("docker-creds"),
 							},
 						},

--- a/pkg/admission/validator/mirror/shoot_test.go
+++ b/pkg/admission/validator/mirror/shoot_test.go
@@ -35,7 +35,7 @@ import (
 	mirrorinstall "github.com/gardener/gardener-extension-registry-cache/pkg/apis/mirror/install"
 	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/mirror/v1alpha1"
 	registryinstall "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/install"
-	registryv1alpha1 "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha1"
+	registryv1alpha2 "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
 )
 
 func TestRegistryMirrorValidator(t *testing.T) {
@@ -197,15 +197,17 @@ var _ = Describe("Shoot validator", func() {
 			shoot.Spec.Extensions = append(shoot.Spec.Extensions, core.Extension{
 				Type: "registry-cache",
 				ProviderConfig: &runtime.RawExtension{
-					Raw: encode(&registryv1alpha1.RegistryConfig{
+					Raw: encode(&registryv1alpha2.RegistryConfig{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: registryv1alpha1.SchemeGroupVersion.String(),
+							APIVersion: registryv1alpha2.SchemeGroupVersion.String(),
 							Kind:       "RegistryConfig",
 						},
-						Caches: []registryv1alpha1.RegistryCache{
+						Caches: []registryv1alpha2.RegistryCache{
 							{
 								Upstream: "docker.io",
-								Size:     &size,
+								Volume: &registryv1alpha2.Volume{
+									Size: &size,
+								},
 							},
 						},
 					}),

--- a/pkg/webhook/cache/ensurer_test.go
+++ b/pkg/webhook/cache/ensurer_test.go
@@ -36,7 +36,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	registryinstall "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/install"
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha1"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
 	"github.com/gardener/gardener-extension-registry-cache/pkg/webhook/cache"
 )
 
@@ -244,12 +244,12 @@ var _ = Describe("Ensurer", func() {
 				Status: extensionsv1alpha1.ExtensionStatus{
 					DefaultStatus: extensionsv1alpha1.DefaultStatus{
 						ProviderStatus: &runtime.RawExtension{
-							Object: &v1alpha1.RegistryStatus{
+							Object: &v1alpha2.RegistryStatus{
 								TypeMeta: metav1.TypeMeta{
-									APIVersion: v1alpha1.SchemeGroupVersion.String(),
+									APIVersion: v1alpha2.SchemeGroupVersion.String(),
 									Kind:       "RegistryStatus",
 								},
-								Caches: []v1alpha1.RegistryCacheStatus{
+								Caches: []v1alpha2.RegistryCacheStatus{
 									{
 										Upstream: "docker.io",
 										Endpoint: "http://10.0.0.1:5000",
@@ -289,12 +289,12 @@ var _ = Describe("Ensurer", func() {
 				Status: extensionsv1alpha1.ExtensionStatus{
 					DefaultStatus: extensionsv1alpha1.DefaultStatus{
 						ProviderStatus: &runtime.RawExtension{
-							Object: &v1alpha1.RegistryStatus{
+							Object: &v1alpha2.RegistryStatus{
 								TypeMeta: metav1.TypeMeta{
-									APIVersion: v1alpha1.SchemeGroupVersion.String(),
+									APIVersion: v1alpha2.SchemeGroupVersion.String(),
 									Kind:       "RegistryStatus",
 								},
-								Caches: []v1alpha1.RegistryCacheStatus{
+								Caches: []v1alpha2.RegistryCacheStatus{
 									{
 										Upstream: "docker.io",
 										Endpoint: "http://10.0.0.1:5000",

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -36,7 +36,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	mirrorv1alpha1 "github.com/gardener/gardener-extension-registry-cache/pkg/apis/mirror/v1alpha1"
-	registryv1alpha1 "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha1"
+	registryv1alpha2 "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
 )
 
 const (
@@ -56,10 +56,10 @@ const (
 )
 
 // AddOrUpdateRegistryCacheExtension adds or updates registry-cache extension with the given caches to the given Shoot.
-func AddOrUpdateRegistryCacheExtension(shoot *gardencorev1beta1.Shoot, caches []registryv1alpha1.RegistryCache) {
-	providerConfig := &registryv1alpha1.RegistryConfig{
+func AddOrUpdateRegistryCacheExtension(shoot *gardencorev1beta1.Shoot, caches []registryv1alpha2.RegistryCache) {
+	providerConfig := &registryv1alpha2.RegistryConfig{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: registryv1alpha1.SchemeGroupVersion.String(),
+			APIVersion: registryv1alpha2.SchemeGroupVersion.String(),
 			Kind:       "RegistryConfig",
 		},
 		Caches: caches,

--- a/test/e2e/cache/create_enable_add_remove_disable_delete.go
+++ b/test/e2e/cache/create_enable_add_remove_disable_delete.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha1"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
 	"github.com/gardener/gardener-extension-registry-cache/test/e2e"
 )
@@ -46,8 +46,8 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 		defer cancel()
 		Expect(f.UpdateShoot(ctx, f.Shoot, func(shoot *gardencorev1beta1.Shoot) error {
 			size := resource.MustParse("2Gi")
-			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
-				{Upstream: "docker.io", Size: &size},
+			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
+				{Upstream: "docker.io", Volume: &v1alpha2.Volume{Size: &size}},
 			})
 
 			return nil
@@ -66,9 +66,9 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 		defer cancel()
 		Expect(f.UpdateShoot(ctx, f.Shoot, func(shoot *gardencorev1beta1.Shoot) error {
 			size := resource.MustParse("2Gi")
-			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
-				{Upstream: "docker.io", Size: &size},
-				{Upstream: "public.ecr.aws", Size: &size},
+			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
+				{Upstream: "docker.io", Volume: &v1alpha2.Volume{Size: &size}},
+				{Upstream: "public.ecr.aws", Volume: &v1alpha2.Volume{Size: &size}},
 			})
 
 			return nil
@@ -87,8 +87,8 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 		defer cancel()
 		Expect(f.UpdateShoot(ctx, f.Shoot, func(shoot *gardencorev1beta1.Shoot) error {
 			size := resource.MustParse("2Gi")
-			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
-				{Upstream: "docker.io", Size: &size},
+			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
+				{Upstream: "docker.io", Volume: &v1alpha2.Volume{Size: &size}},
 			})
 
 			return nil

--- a/test/e2e/cache/create_enabled_delete_shoot_system_components.go
+++ b/test/e2e/cache/create_enabled_delete_shoot_system_components.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha1"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
 	"github.com/gardener/gardener-extension-registry-cache/test/e2e"
 )
@@ -33,10 +33,10 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 	f := e2e.DefaultShootCreationFramework()
 	shoot := e2e.DefaultShoot("e2e-cache-ssc")
 	size := resource.MustParse("2Gi")
-	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
-		{Upstream: "europe-docker.pkg.dev", Size: &size},
-		{Upstream: "quay.io", Size: &size},
-		{Upstream: "registry.k8s.io", Size: &size},
+	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
+		{Upstream: "europe-docker.pkg.dev", Volume: &v1alpha2.Volume{Size: &size}},
+		{Upstream: "quay.io", Volume: &v1alpha2.Volume{Size: &size}},
+		{Upstream: "registry.k8s.io", Volume: &v1alpha2.Volume{Size: &size}},
 	})
 	f.Shoot = shoot
 

--- a/test/e2e/cache/create_enabled_force_delete.go
+++ b/test/e2e/cache/create_enabled_force_delete.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha1"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
 	"github.com/gardener/gardener-extension-registry-cache/test/e2e"
 )
@@ -33,8 +33,8 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 	f := e2e.DefaultShootCreationFramework()
 	shoot := e2e.DefaultShoot("e2e-cache-fd")
 	size := resource.MustParse("2Gi")
-	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
-		{Upstream: "docker.io", Size: &size},
+	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
+		{Upstream: "docker.io", Volume: &v1alpha2.Volume{Size: &size}},
 	})
 	f.Shoot = shoot
 

--- a/test/e2e/cache/create_enabled_hibernate_reconcile_delete.go
+++ b/test/e2e/cache/create_enabled_hibernate_reconcile_delete.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha1"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
 	"github.com/gardener/gardener-extension-registry-cache/test/e2e"
 )
@@ -35,8 +35,8 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 	f := e2e.DefaultShootCreationFramework()
 	shoot := e2e.DefaultShoot("e2e-cache-hib")
 	size := resource.MustParse("2Gi")
-	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
-		{Upstream: "docker.io", Size: &size},
+	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
+		{Upstream: "docker.io", Volume: &v1alpha2.Volume{Size: &size}},
 	})
 	f.Shoot = shoot
 

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha1"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
 )
 
@@ -47,8 +47,8 @@ var _ = Describe("Shoot registry cache testing", func() {
 				size = resource.MustParse("20Gi")
 			}
 
-			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
-				{Upstream: "docker.io", Size: &size},
+			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
+				{Upstream: "docker.io", Volume: &v1alpha2.Volume{Size: &size}},
 			})
 
 			return nil

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha1"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
 )
 
@@ -49,8 +49,8 @@ var _ = Describe("Shoot registry cache testing", func() {
 				size = resource.MustParse("20Gi")
 			}
 
-			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha1.RegistryCache{
-				{Upstream: "docker.io", Size: &size},
+			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
+				{Upstream: "docker.io", Volume: &v1alpha2.Volume{Size: &size}},
 			})
 
 			return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
This PR is a preparation for the v1alpha1 API removal.

**Which issue(s) this PR fixes**:
Part of #3

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
