### PR TITLE
Clean up v1alpha2 usages

### DIFF
--- a/pkg/admission/validator/cache/shoot_test.go
+++ b/pkg/admission/validator/cache/shoot_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/gardener/gardener-extension-registry-cache/pkg/admission/validator/cache"
 	api "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry"
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 )
 
 func TestRegistryCacheValidator(t *testing.T) {
@@ -54,7 +54,7 @@ var _ = Describe("Shoot validator", func() {
 		BeforeEach(func() {
 			scheme := runtime.NewScheme()
 			Expect(api.AddToScheme(scheme)).To(Succeed())
-			Expect(v1alpha2.AddToScheme(scheme)).To(Succeed())
+			Expect(v1alpha3.AddToScheme(scheme)).To(Succeed())
 
 			decoder := serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder()
 			ctrl = gomock.NewController(GinkgoT())
@@ -72,15 +72,15 @@ var _ = Describe("Shoot validator", func() {
 						{
 							Type: "registry-cache",
 							ProviderConfig: &runtime.RawExtension{
-								Raw: encode(&v1alpha2.RegistryConfig{
+								Raw: encode(&v1alpha3.RegistryConfig{
 									TypeMeta: metav1.TypeMeta{
-										APIVersion: v1alpha2.SchemeGroupVersion.String(),
+										APIVersion: v1alpha3.SchemeGroupVersion.String(),
 										Kind:       "RegistryConfig",
 									},
-									Caches: []v1alpha2.RegistryCache{
+									Caches: []v1alpha3.RegistryCache{
 										{
 											Upstream: "docker.io",
-											Volume: &v1alpha2.Volume{
+											Volume: &v1alpha3.Volume{
 												Size: &size,
 											},
 										},
@@ -146,12 +146,12 @@ var _ = Describe("Shoot validator", func() {
 
 			It("should return err when registry-cache providerConfig is invalid", func() {
 				shoot.Spec.Extensions[0].ProviderConfig = &runtime.RawExtension{
-					Raw: encode(&v1alpha2.RegistryConfig{
+					Raw: encode(&v1alpha3.RegistryConfig{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: v1alpha2.SchemeGroupVersion.String(),
+							APIVersion: v1alpha3.SchemeGroupVersion.String(),
 							Kind:       "RegistryConfig",
 						},
-						Caches: []v1alpha2.RegistryCache{
+						Caches: []v1alpha3.RegistryCache{
 							{
 								Upstream: "https://registry.example.com",
 							},
@@ -203,15 +203,15 @@ var _ = Describe("Shoot validator", func() {
 			It("should return err when registry-cache providerConfig update is invalid", func() {
 				newSize := resource.MustParse("42Gi")
 				shoot.Spec.Extensions[0].ProviderConfig = &runtime.RawExtension{
-					Raw: encode(&v1alpha2.RegistryConfig{
+					Raw: encode(&v1alpha3.RegistryConfig{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: v1alpha2.SchemeGroupVersion.String(),
+							APIVersion: v1alpha3.SchemeGroupVersion.String(),
 							Kind:       "RegistryConfig",
 						},
-						Caches: []v1alpha2.RegistryCache{
+						Caches: []v1alpha3.RegistryCache{
 							{
 								Upstream: "docker.io",
-								Volume: &v1alpha2.Volume{
+								Volume: &v1alpha3.Volume{
 									Size: &newSize,
 								},
 							},
@@ -258,15 +258,15 @@ var _ = Describe("Shoot validator", func() {
 					},
 				}
 				shoot.Spec.Extensions[0].ProviderConfig = &runtime.RawExtension{
-					Raw: encode(&v1alpha2.RegistryConfig{
+					Raw: encode(&v1alpha3.RegistryConfig{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: v1alpha2.SchemeGroupVersion.String(),
+							APIVersion: v1alpha3.SchemeGroupVersion.String(),
 							Kind:       "RegistryConfig",
 						},
-						Caches: []v1alpha2.RegistryCache{
+						Caches: []v1alpha3.RegistryCache{
 							{
 								Upstream: "docker.io",
-								Volume: &v1alpha2.Volume{
+								Volume: &v1alpha3.Volume{
 									Size: &size,
 								},
 								SecretReferenceName: ptr.To("docker-creds"),

--- a/pkg/admission/validator/mirror/shoot_test.go
+++ b/pkg/admission/validator/mirror/shoot_test.go
@@ -25,7 +25,7 @@ import (
 	mirrorinstall "github.com/gardener/gardener-extension-registry-cache/pkg/apis/mirror/install"
 	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/mirror/v1alpha1"
 	registryinstall "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/install"
-	registryv1alpha2 "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
+	registryv1alpha3 "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 )
 
 func TestRegistryMirrorValidator(t *testing.T) {
@@ -187,15 +187,15 @@ var _ = Describe("Shoot validator", func() {
 			shoot.Spec.Extensions = append(shoot.Spec.Extensions, core.Extension{
 				Type: "registry-cache",
 				ProviderConfig: &runtime.RawExtension{
-					Raw: encode(&registryv1alpha2.RegistryConfig{
+					Raw: encode(&registryv1alpha3.RegistryConfig{
 						TypeMeta: metav1.TypeMeta{
-							APIVersion: registryv1alpha2.SchemeGroupVersion.String(),
+							APIVersion: registryv1alpha3.SchemeGroupVersion.String(),
 							Kind:       "RegistryConfig",
 						},
-						Caches: []registryv1alpha2.RegistryCache{
+						Caches: []registryv1alpha3.RegistryCache{
 							{
 								Upstream: "docker.io",
-								Volume: &registryv1alpha2.Volume{
+								Volume: &registryv1alpha3.Volume{
 									Size: &size,
 								},
 							},

--- a/pkg/controller/cache/actuator.go
+++ b/pkg/controller/cache/actuator.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gardener/gardener-extension-registry-cache/imagevector"
 	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/config"
 	api "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry"
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 	"github.com/gardener/gardener-extension-registry-cache/pkg/component/registrycaches"
 	"github.com/gardener/gardener-extension-registry-cache/pkg/component/registryconfigurationcleaner"
 	"github.com/gardener/gardener-extension-registry-cache/pkg/constants"
@@ -192,7 +192,7 @@ func (a *actuator) ForceDelete(ctx context.Context, _ logr.Logger, ex *extension
 	return nil
 }
 
-func (a *actuator) computeProviderStatus(ctx context.Context, registryConfig *api.RegistryConfig, namespace string) (*v1alpha2.RegistryStatus, error) {
+func (a *actuator) computeProviderStatus(ctx context.Context, registryConfig *api.RegistryConfig, namespace string) (*v1alpha3.RegistryStatus, error) {
 	// get service IPs from shoot
 	_, shootClient, err := util.NewClientForShoot(ctx, a.client, namespace, client.Options{}, extensionsconfig.RESTOptions{})
 	if err != nil {
@@ -216,24 +216,24 @@ func (a *actuator) computeProviderStatus(ctx context.Context, registryConfig *ap
 		return nil, fmt.Errorf("not all services for all configured caches exist")
 	}
 
-	caches := []v1alpha2.RegistryCacheStatus{}
+	caches := []v1alpha3.RegistryCacheStatus{}
 	for _, service := range services.Items {
-		caches = append(caches, v1alpha2.RegistryCacheStatus{
+		caches = append(caches, v1alpha3.RegistryCacheStatus{
 			Upstream: service.Labels[constants.UpstreamHostLabel],
 			Endpoint: fmt.Sprintf("http://%s:%d", service.Spec.ClusterIP, constants.RegistryCachePort),
 		})
 	}
 
-	return &v1alpha2.RegistryStatus{
+	return &v1alpha3.RegistryStatus{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: v1alpha2.SchemeGroupVersion.String(),
+			APIVersion: v1alpha3.SchemeGroupVersion.String(),
 			Kind:       "RegistryStatus",
 		},
 		Caches: caches,
 	}, nil
 }
 
-func (a *actuator) updateProviderStatus(ctx context.Context, ex *extensionsv1alpha1.Extension, registryStatus *v1alpha2.RegistryStatus) error {
+func (a *actuator) updateProviderStatus(ctx context.Context, ex *extensionsv1alpha1.Extension, registryStatus *v1alpha3.RegistryStatus) error {
 	patch := client.MergeFrom(ex.DeepCopy())
 	ex.Status.ProviderStatus = &runtime.RawExtension{Object: registryStatus}
 	return a.client.Status().Patch(ctx, ex, patch)

--- a/pkg/webhook/cache/ensurer_test.go
+++ b/pkg/webhook/cache/ensurer_test.go
@@ -26,7 +26,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	registryinstall "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/install"
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 	"github.com/gardener/gardener-extension-registry-cache/pkg/webhook/cache"
 )
 
@@ -234,12 +234,12 @@ var _ = Describe("Ensurer", func() {
 				Status: extensionsv1alpha1.ExtensionStatus{
 					DefaultStatus: extensionsv1alpha1.DefaultStatus{
 						ProviderStatus: &runtime.RawExtension{
-							Object: &v1alpha2.RegistryStatus{
+							Object: &v1alpha3.RegistryStatus{
 								TypeMeta: metav1.TypeMeta{
-									APIVersion: v1alpha2.SchemeGroupVersion.String(),
+									APIVersion: v1alpha3.SchemeGroupVersion.String(),
 									Kind:       "RegistryStatus",
 								},
-								Caches: []v1alpha2.RegistryCacheStatus{
+								Caches: []v1alpha3.RegistryCacheStatus{
 									{
 										Upstream: "docker.io",
 										Endpoint: "http://10.0.0.1:5000",
@@ -279,12 +279,12 @@ var _ = Describe("Ensurer", func() {
 				Status: extensionsv1alpha1.ExtensionStatus{
 					DefaultStatus: extensionsv1alpha1.DefaultStatus{
 						ProviderStatus: &runtime.RawExtension{
-							Object: &v1alpha2.RegistryStatus{
+							Object: &v1alpha3.RegistryStatus{
 								TypeMeta: metav1.TypeMeta{
-									APIVersion: v1alpha2.SchemeGroupVersion.String(),
+									APIVersion: v1alpha3.SchemeGroupVersion.String(),
 									Kind:       "RegistryStatus",
 								},
-								Caches: []v1alpha2.RegistryCacheStatus{
+								Caches: []v1alpha3.RegistryCacheStatus{
 									{
 										Upstream: "docker.io",
 										Endpoint: "http://10.0.0.1:5000",

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -26,7 +26,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	mirrorv1alpha1 "github.com/gardener/gardener-extension-registry-cache/pkg/apis/mirror/v1alpha1"
-	registryv1alpha2 "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
+	registryv1alpha3 "github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 )
 
 const (
@@ -46,10 +46,10 @@ const (
 )
 
 // AddOrUpdateRegistryCacheExtension adds or updates registry-cache extension with the given caches to the given Shoot.
-func AddOrUpdateRegistryCacheExtension(shoot *gardencorev1beta1.Shoot, caches []registryv1alpha2.RegistryCache) {
-	providerConfig := &registryv1alpha2.RegistryConfig{
+func AddOrUpdateRegistryCacheExtension(shoot *gardencorev1beta1.Shoot, caches []registryv1alpha3.RegistryCache) {
+	providerConfig := &registryv1alpha3.RegistryConfig{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: registryv1alpha2.SchemeGroupVersion.String(),
+			APIVersion: registryv1alpha3.SchemeGroupVersion.String(),
 			Kind:       "RegistryConfig",
 		},
 		Caches: caches,

--- a/test/e2e/cache/create_enable_add_remove_disable_delete.go
+++ b/test/e2e/cache/create_enable_add_remove_disable_delete.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
 	"github.com/gardener/gardener-extension-registry-cache/test/e2e"
 )
@@ -36,8 +36,8 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 		defer cancel()
 		Expect(f.UpdateShoot(ctx, f.Shoot, func(shoot *gardencorev1beta1.Shoot) error {
 			size := resource.MustParse("2Gi")
-			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
-				{Upstream: "docker.io", Volume: &v1alpha2.Volume{Size: &size}},
+			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha3.RegistryCache{
+				{Upstream: "docker.io", Volume: &v1alpha3.Volume{Size: &size}},
 			})
 
 			return nil
@@ -56,9 +56,9 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 		defer cancel()
 		Expect(f.UpdateShoot(ctx, f.Shoot, func(shoot *gardencorev1beta1.Shoot) error {
 			size := resource.MustParse("2Gi")
-			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
-				{Upstream: "docker.io", Volume: &v1alpha2.Volume{Size: &size}},
-				{Upstream: "public.ecr.aws", Volume: &v1alpha2.Volume{Size: &size}},
+			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha3.RegistryCache{
+				{Upstream: "docker.io", Volume: &v1alpha3.Volume{Size: &size}},
+				{Upstream: "public.ecr.aws", Volume: &v1alpha3.Volume{Size: &size}},
 			})
 
 			return nil
@@ -77,8 +77,8 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 		defer cancel()
 		Expect(f.UpdateShoot(ctx, f.Shoot, func(shoot *gardencorev1beta1.Shoot) error {
 			size := resource.MustParse("2Gi")
-			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
-				{Upstream: "docker.io", Volume: &v1alpha2.Volume{Size: &size}},
+			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha3.RegistryCache{
+				{Upstream: "docker.io", Volume: &v1alpha3.Volume{Size: &size}},
 			})
 
 			return nil

--- a/test/e2e/cache/create_enabled_delete_shoot_system_components.go
+++ b/test/e2e/cache/create_enabled_delete_shoot_system_components.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
 	"github.com/gardener/gardener-extension-registry-cache/test/e2e"
 )
@@ -23,10 +23,10 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 	f := e2e.DefaultShootCreationFramework()
 	shoot := e2e.DefaultShoot("e2e-cache-ssc")
 	size := resource.MustParse("2Gi")
-	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
-		{Upstream: "europe-docker.pkg.dev", Volume: &v1alpha2.Volume{Size: &size}},
-		{Upstream: "quay.io", Volume: &v1alpha2.Volume{Size: &size}},
-		{Upstream: "registry.k8s.io", Volume: &v1alpha2.Volume{Size: &size}},
+	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha3.RegistryCache{
+		{Upstream: "europe-docker.pkg.dev", Volume: &v1alpha3.Volume{Size: &size}},
+		{Upstream: "quay.io", Volume: &v1alpha3.Volume{Size: &size}},
+		{Upstream: "registry.k8s.io", Volume: &v1alpha3.Volume{Size: &size}},
 	})
 	f.Shoot = shoot
 

--- a/test/e2e/cache/create_enabled_force_delete.go
+++ b/test/e2e/cache/create_enabled_force_delete.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
 	"github.com/gardener/gardener-extension-registry-cache/test/e2e"
 )
@@ -23,8 +23,8 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 	f := e2e.DefaultShootCreationFramework()
 	shoot := e2e.DefaultShoot("e2e-cache-fd")
 	size := resource.MustParse("2Gi")
-	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
-		{Upstream: "docker.io", Volume: &v1alpha2.Volume{Size: &size}},
+	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha3.RegistryCache{
+		{Upstream: "docker.io", Volume: &v1alpha3.Volume{Size: &size}},
 	})
 	f.Shoot = shoot
 

--- a/test/e2e/cache/create_enabled_hibernate_reconcile_delete.go
+++ b/test/e2e/cache/create_enabled_hibernate_reconcile_delete.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
 	"github.com/gardener/gardener-extension-registry-cache/test/e2e"
 )
@@ -25,8 +25,8 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 	f := e2e.DefaultShootCreationFramework()
 	shoot := e2e.DefaultShoot("e2e-cache-hib")
 	size := resource.MustParse("2Gi")
-	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
-		{Upstream: "docker.io", Volume: &v1alpha2.Volume{Size: &size}},
+	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha3.RegistryCache{
+		{Upstream: "docker.io", Volume: &v1alpha3.Volume{Size: &size}},
 	})
 	f.Shoot = shoot
 

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
 )
 
@@ -37,8 +37,8 @@ var _ = Describe("Shoot registry cache testing", func() {
 				size = resource.MustParse("20Gi")
 			}
 
-			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
-				{Upstream: "docker.io", Volume: &v1alpha2.Volume{Size: &size}},
+			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha3.RegistryCache{
+				{Upstream: "docker.io", Volume: &v1alpha3.Volume{Size: &size}},
 			})
 
 			return nil

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha2"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
 )
 
@@ -39,8 +39,8 @@ var _ = Describe("Shoot registry cache testing", func() {
 				size = resource.MustParse("20Gi")
 			}
 
-			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha2.RegistryCache{
-				{Upstream: "docker.io", Volume: &v1alpha2.Volume{Size: &size}},
+			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha3.RegistryCache{
+				{Upstream: "docker.io", Volume: &v1alpha3.Volume{Size: &size}},
 			})
 
 			return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
This PR is a preparation for the v1alpha2 API removal.

**Which issue(s) this PR fixes**:
Part of #3

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
