### PR TITLE
Improve the upstream credentials docs

### DIFF
--- a/.ci/third_party/component_descriptor
+++ b/.ci/third_party/component_descriptor
@@ -2,6 +2,10 @@
 
 # This file is copied from https://github.com/gardener/gardener/blob/master/hack/.ci/component_descriptor. Keep it in sync.
 
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # Configuration Options:
 #
 # COMPONENT_PREFIXES: Set the image prefix that should be used to

--- a/.ci/third_party/prepare_release
+++ b/.ci/third_party/prepare_release
@@ -2,19 +2,9 @@
 #
 # This file is copied from https://github.com/gardener/gardener/blob/master/hack/.ci/prepare_release. Keep it in sync.
 #
-# Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
 
 set -e
 

--- a/docs/usage/registry-cache/configuration.md
+++ b/docs/usage/registry-cache/configuration.md
@@ -132,7 +132,7 @@ The registry cache runs with a single replica. This fact may lead to concerns fo
 
 ## Gotchas
 
-- The used registry implementation ([distribution/distribution](https://github.com/distribution/distribution)) supports mirroring of only one upstream registry. The extension deploys a pull-through cache for each configured upstream.
+- The used registry implementation (the [Distribution project](https://github.com/distribution/distribution)) supports mirroring of only one upstream registry. The extension deploys a pull-through cache for each configured upstream.
 - `us-docker.pkg.dev`, `europe-docker.pkg.dev`, and `asia-docker.pkg.dev` are different upstreams. Hence, configuring `pkg.dev` as upstream won't cache images from `us-docker.pkg.dev`, `europe-docker.pkg.dev`, or `asia-docker.pkg.dev`.
 
 ## Limitations

--- a/docs/usage/registry-cache/upstream-credentials.md
+++ b/docs/usage/registry-cache/upstream-credentials.md
@@ -1,6 +1,11 @@
 # How to provide credentials for upstream registry?
 
-In order to pull private images through registry cache, it is required to supply credentials for the private upstream registry.
+In Kubernetes, to pull images from private container image registries you either have to specify an image pull Secret (see [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)) or you have to configure kubelet to dynamically retrieve credentials using a credential provider plugin (see [Configure a kubelet image credential provider](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/)). When pulling an image, kubelet is providing the credentials to the CRI implementation. The CRI implementation uses the provided credentials against the upstream registry to pull the image.
+
+The registry-cache extension is using the [Distribution project](https://github.com/distribution/distribution) as pull through cache implementation. The Distribution project does not use the provided credentials from the CRI implementation while fetching an image from the upstream. Hence, the above-described scenarios such as configuring image pull Secret for a Pod or configuring kubelet credential provider plugins don't work out of the box with the pull through cache provided by the registry-cache extension.
+Instead, the Distribution project supports configuring only one set of credentials for a given pull through cache instance (for a given upstream).
+
+This document describe how to supply credentials for the private upstream registry in order to pull private image with the registry cache.
 
 ## How to configure the registry cache to use upstream registry credentials?
 
@@ -65,4 +70,5 @@ To rotate registry credentials perform the following steps:
 
 ## Gotchas
 
+- The registry cache is not protected by any authentication/authorization mechanism. The caches images (incl. private images) can be fetched from the registry cache without authentication/authorization. Note that the registry cache itself is not exposed publicly.
 - The registry cache provides the credentials for every request against the corresponding upstream. In some cases, misconfigured credentials can prevent the registry cache to pull even public images from the upstream (for example: invalid service account key for Artifact Registry). However, this behaviour is controlled by the server-side logic of the upstream registry.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
This PR improves the upstream credentials docs by described how generally things work in K8s (without registry cache) and what is the limitation in the Distribution project that forces the people to provide their credentials one more time (for the registry cache).

**Which issue(s) this PR fixes**:
Part of #3

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
