### PR TITLE
Fix links to gardener/gardener docs

### DIFF
--- a/docs/development/extension-registry-cache.md
+++ b/docs/development/extension-registry-cache.md
@@ -13,24 +13,24 @@ This section outlines how the reconciliation works for a Shoot with the registry
 
 #### Extension enablement/reconciliation
 
-This section outlines how the extension enablement/reconciliation works, e.g the extension has beeen added to the Shoot spec.
+This section outlines how the extension enablement/reconciliation works, e.g. the extension has been added to the Shoot spec.
 
-1. As part of the Shoot reconciliation flow, gardenlet deploys the [Extension](https://github.com/gardener/gardener/blob/v1.82.0/docs/extensions/extension.md) resource.
-1. The registry-cache extension reconciles the Extension resource. [pkg/controller/cache/actuator.go](../../pkg/controller/cache/actuator.go) contains the implementation of the [extension.Actuator](https://github.com/gardener/gardener/blob/v1.82.0/extensions/pkg/controller/extension/actuator.go) interface. The reconciliation of an Extension of type `registry-cache` consists of the following steps:
+1. As part of the Shoot reconciliation flow, gardenlet deploys the [Extension](https://github.com/gardener/gardener/blob/master/docs/extensions/extension.md) resource.
+1. The registry-cache extension reconciles the Extension resource. [pkg/controller/cache/actuator.go](../../pkg/controller/cache/actuator.go) contains the implementation of the [extension.Actuator](https://github.com/gardener/gardener/blob/v1.88.0/extensions/pkg/controller/extension/actuator.go) interface. The reconciliation of an Extension of type `registry-cache` consists of the following steps:
    1. The extension checks if a registry has been removed (by comparing the status and the spec of the Extension). If an upstream is being removed, then it deploys the [`registry-cleaner` DaemonSet](../../pkg/component/registryconfigurationcleaner/registry_configuration_cleaner.go) to the Shoot cluster to clean up the existing configuration for the upstream that has to be removed.
    1. The registry-cache extension deploys resources to the Shoot cluster via ManagedResource. For every configured upstream it creates a StatefulSet (with PVC), Service and other resources.
    1. It lists all Services from the `kube-system` namespace having the `upstream-host` label. It will return an error (and retry in exponential backoff) until the Services count matches the configured registries count.
    1. When there is a Service created for each configured upstream registry, the registry-cache extension populates the Extension resource status. In the Extension status, for each upstream, it maintains an endpoint (in format `http://<cluster-ip>:5000`) which can be used to access the registry cache from within the Shoot cluster. `<cluster-ip>` is the cluster IP of the registry cache Service. The cluster IP of a Service is assigned by the Kubernetes API server on Service creation.
-1. As part of the Shoot reconciliation flow, gardenlet deploys the [OperatingSystemConfig](https://github.com/gardener/gardener/blob/v1.82.0/docs/extensions/operatingsystemconfig.md) resource.
-1. The registry-cache extension serves a webhook that mutates the OperatingSystemConfig resource for Shoots having the registry-cache extension enabled (the corresponding namespace gets labeled by gardenlet with `extensions.gardener.cloud/registry-cache=true`). [pkg/webhook/cache/ensurer.go](../../pkg/webhook/cache/ensurer.go) contains implementation of the [genericmutator.Ensurer](https://github.com/gardener/gardener/blob/v1.82.0/extensions/pkg/webhook/controlplane/genericmutator/mutator.go) interface.
+1. As part of the Shoot reconciliation flow, gardenlet deploys the [OperatingSystemConfig](https://github.com/gardener/gardener/blob/master/docs/extensions/operatingsystemconfig.md) resource.
+1. The registry-cache extension serves a webhook that mutates the OperatingSystemConfig resource for Shoots having the registry-cache extension enabled (the corresponding namespace gets labeled by gardenlet with `extensions.gardener.cloud/registry-cache=true`). [pkg/webhook/cache/ensurer.go](../../pkg/webhook/cache/ensurer.go) contains implementation of the [genericmutator.Ensurer](https://github.com/gardener/gardener/blob/v1.88.0/extensions/pkg/webhook/controlplane/genericmutator/mutator.go) interface.
    1. The webhook appends the [configure-containerd-registries.sh](../../pkg/webhook/cache/scripts/configure-containerd-registries.sh) script to the OperatingSystemConfig files. The script accepts registries in the format `<upstream_host>,<registry_cache_endpoint>,<upstream_url>` separated by a space. For each given registry the script waits until the given registry is available (a request to the `<registry_cache_endpoint>` succeeds). Then it creates a `hosts.toml` file for the given `<upstream_host>`. In short, the `hosts.toml` file instructs containerd to first try to pull images for the given `<upstream_host>` from the configured `<registry_cache_endpoint>`. For more information about containerd registry configuration, see the [containerd documentation](https://github.com/containerd/containerd/blob/main/docs/hosts.md). The motivation to introduce the `configure-containerd-registries.sh` script is that we need to create the `hosts.toml` file when the corresponding registry is available. For more details, see https://github.com/gardener/gardener-extension-registry-cache/pull/68.
-   1. The webhook appends the `configure-containerd-registries.service` unit to the OperatingSystemConfig units. The webhook fetches the Extension resource and then it configures the unit to invoke the `configure-containerd-registries.sh` script with the registries from the Extension status.
+   1. The webhook appends the `configure-containerd-registries.service` unit to the OperatingSystemConfig units. The webhook fetches the Extension resource, and then it configures the unit to invoke the `configure-containerd-registries.sh` script with the registries from the Extension status.
 
 #### Extension disablement
 
-This section outlines how the extension disablement works, i.e the extension has be removed from the Shoot spec.
+This section outlines how the extension disablement works, i.e. the extension has be removed from the Shoot spec.
 
-1. As part of the Shoot reconciliation flow, gardenlet destroys the [Extension](https://github.com/gardener/gardener/blob/v1.82.0/docs/extensions/extension.md) resource because it is no longer needed.
+1. As part of the Shoot reconciliation flow, gardenlet destroys the [Extension](https://github.com/gardener/gardener/blob/master/docs/extensions/extension.md) resource because it is no longer needed.
    1. If the Extension resource contains registries in its status, the registry-cache extension deploys the [`registry-cleaner` DaemonSet](../../pkg/component/registryconfigurationcleaner/registry_configuration_cleaner.go) to the Shoot cluster to clean up the existing registry configuration.
    1. The extension deletes the ManagedResource containing the registry cache resources.
 
@@ -38,6 +38,6 @@ This section outlines how the extension disablement works, i.e the extension has
 
 This section outlines how the deletion works for a Shoot with the registry-cache extension enabled.
 
-1. As part of the Shoot deletion flow, gardenlet destroys the [Extension](https://github.com/gardener/gardener/blob/v1.82.0/docs/extensions/extension.md) resource.
+1. As part of the Shoot deletion flow, gardenlet destroys the [Extension](https://github.com/gardener/gardener/blob/master/docs/extensions/extension.md) resource.
    1. In the Shoot deletion flow the Extension resource is deleted after the Worker resource. Hence, there is no need to deploy the [`registry-cleaner` DaemonSet](../../pkg/component/registryconfigurationcleaner/registry_configuration_cleaner.go) to the Shoot cluster to clean up the existing registry configuration.
    1. The extension deletes the ManagedResource containing the registry cache resources.

--- a/docs/development/getting-started-locally.md
+++ b/docs/development/getting-started-locally.md
@@ -19,7 +19,7 @@ make extension-up
 
 The corresponding make target will build the extension image, load it into the kind cluster Nodes, and deploy the registry-cache ControllerDeployment and ControllerRegistration resources. The container image in the ControllerDeployment will be the image that was build and loaded into the kind cluster Nodes.
 
-The make target will then deploy registry-cache admission component. It will build the admission image, load it into the kind cluster Nodes, and finally install the admission component charts to the kind cluster.
+The make target will then deploy the registry-cache admission component. It will build the admission image, load it into the kind cluster Nodes, and finally install the admission component charts to the kind cluster.
 
 ## Creating a `Shoot` Cluster
 

--- a/docs/development/getting-started-locally.md
+++ b/docs/development/getting-started-locally.md
@@ -19,7 +19,7 @@ make extension-up
 
 The corresponding make target will build the extension image, load it into the kind cluster Nodes, and deploy the registry-cache ControllerDeployment and ControllerRegistration resources. The container image in the ControllerDeployment will be the image that was build and loaded into the kind cluster Nodes.
 
-The make target will then deploy then registry-cache admission component. It will build the admission image, load it into the kind cluster Nodes, and finally install the admission component charts to the kind cluster.
+The make target will then deploy registry-cache admission component. It will build the admission image, load it into the kind cluster Nodes, and finally install the admission component charts to the kind cluster.
 
 ## Creating a `Shoot` Cluster
 

--- a/docs/usage/registry-cache/configuration.md
+++ b/docs/usage/registry-cache/configuration.md
@@ -78,7 +78,7 @@ The registry-cache extension deploys a StatefulSet with a volume claim template.
 
 The `providerConfig.caches[].volume.size` field is the size of the registry cache volume. Defaults to `10Gi`. The size must be a positive quantity (greater than 0).
 This field is immutable. See [Increase the cache disk size](#increase-the-cache-disk-size) on how to resize the disk.
-The extension defines [alerts](../../../pkg/component/registrycaches/alerting-rules/registry-cache.rules.yaml) for the volume. See [Alerting for Users](https://github.com/gardener/gardener/blob/v1.82.0/docs/monitoring/alerting.md#alerting-for-users) on how to enable notifications for Shoot cluster alerts.
+The extension defines [alerts](../../../pkg/component/registrycaches/alerting-rules/registry-cache.rules.yaml) for the volume. See [Alerting for Users](https://github.com/gardener/gardener/blob/master/docs/monitoring/alerting.md#alerting-for-users) on how to enable notifications for Shoot cluster alerts.
 
 The `providerConfig.caches[].volume.storageClassName` field is the name of the StorageClass used by the registry cache volume.
 This field is immutable. If the field is not specified, then the [default StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/#default-storageclass) will be used.

--- a/docs/usage/registry-cache/migration-from-v1alpha2-to-v1alpha3.md
+++ b/docs/usage/registry-cache/migration-from-v1alpha2-to-v1alpha3.md
@@ -5,7 +5,7 @@ description: Learn how to migrate from the `v1alpha2` API version of the `Regist
 
 # Migration from `v1alpha2` to `v1alpha3`
 
-This document descibres how to migrate from API version `registry.extensions.gardener.cloud/v1alpha2` of the `RegistryConfig` to `registry.extensions.gardener.cloud/v1alpha3`.
+This document describes how to migrate from API version `registry.extensions.gardener.cloud/v1alpha2` of the `RegistryConfig` to `registry.extensions.gardener.cloud/v1alpha3`.
 
 The `registry.extensions.gardener.cloud/v1alpha2` is deprecated and will be removed in a future version. Use `registry.extensions.gardener.cloud/v1alpha3` instead.
 

--- a/docs/usage/registry-cache/upstream-credentials.md
+++ b/docs/usage/registry-cache/upstream-credentials.md
@@ -65,14 +65,14 @@ This document describe how to supply credentials for the private upstream regist
 ## How to rotate the registry credentials?
 
 To rotate registry credentials perform the following steps:
-1. Generate new pair of credentials in the cloud provider account. Do not invalidate the old ones.
+1. Generate a new pair of credentials in the cloud provider account. Do not invalidate the old ones.
 1. Create a new Secret (e.g. `ro-docker-secret-v2`) with the newly generated credentials as described step 1. in [How to configure the registry cache to use upstream registry credentials?](#how-to-configure-the-registry-cache-to-use-upstream-registry-credentials).
 1. Update the Shoot spec with newly created Secret as described step 2. in [How to configure the registry cache to use upstream registry credentials?](#how-to-configure-the-registry-cache-to-use-upstream-registry-credentials).
-1 The above step will trigger a Shoot reconciliation. Wait for the Shoot reconciliation to complete.
+1. The above step will trigger a Shoot reconciliation. Wait for the Shoot reconciliation to complete.
 1. Make sure that the old Secret is no longer referenced by any Shoot cluster. Finally, delete the Secret containing the old credentials (e.g. `ro-docker-secret-v1`).
 1. Delete the corresponding old credentials from the cloud provider account.
 
 ## Gotchas
 
-- The registry cache is not protected by any authentication/authorization mechanism. The caches images (incl. private images) can be fetched from the registry cache without authentication/authorization. Note that the registry cache itself is not exposed publicly.
+- The registry cache is not protected by any authentication/authorization mechanism. The cached images (incl. private images) can be fetched from the registry cache without authentication/authorization. Note that the registry cache itself is not exposed publicly.
 - The registry cache provides the credentials for every request against the corresponding upstream. In some cases, misconfigured credentials can prevent the registry cache to pull even public images from the upstream (for example: invalid service account key for Artifact Registry). However, this behaviour is controlled by the server-side logic of the upstream registry.

--- a/docs/usage/registry-mirror/configuration.md
+++ b/docs/usage/registry-mirror/configuration.md
@@ -21,7 +21,7 @@ The registry-mirror extension allows registry mirror configuration to be configu
 
 When the extension is enabled, the containerd daemon on the Shoot cluster Nodes gets configured to use as a mirror the requested mirrors. For example, if for upstream `docker.io` the mirror `https://mirror.gcr.io` is configured in the Shoot spec, then containerd gets configured to first pull the image from the mirror (`https://mirror.gcr.io` in that case). If this image pull operation fails, containerd falls back to the upstream itself (`docker.io` in that case).
 
-The extension is based on the contract described in [`containerd` Registry Configuration](https://github.com/gardener/gardener/blob/v1.87.0/docs/usage/containerd-registry-configuration.md). The corresponding upstream documentation in containerd is [Registry Configuration - Introduction](https://github.com/containerd/containerd/blob/v1.7.0/docs/hosts.md).
+The extension is based on the contract described in [`containerd` Registry Configuration](https://github.com/gardener/gardener/blob/master/docs/usage/containerd-registry-configuration.md). The corresponding upstream documentation in containerd is [Registry Configuration - Introduction](https://github.com/containerd/containerd/blob/v1.7.0/docs/hosts.md).
 
 ## Shoot Configuration
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
All links to documents in [gardener/gardener](https://github.com/gardener/gardener) are changed to point to master branch. In this way the links in the https://gardener.cloud/docs/ will be relative internal links and will no longer point to github. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
