### PR TITLE
Add recording rules that will be federated by aggregate prometheus and garden-prometheus

### DIFF
--- a/pkg/component/registrycaches/alerting-rules/registry-cache.rules.yaml
+++ b/pkg/component/registrycaches/alerting-rules/registry-cache.rules.yaml
@@ -35,3 +35,11 @@ groups:
     annotations:
       summary: Registry cache PersistentVolume will be full in four days.
       description: Based on recent sampling, the registry cache PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} is expected to fill up within four days. Currently {{ printf "%0.2f" $value }}% is available.
+
+  # We rely on the implicit contract that recording rules in format "shoot:(.+):(.+)" will be
+  # automatically federated to the aggregate prometheus and then to the garden-prometheus.
+  # Ref https://github.com/gardener/gardener/blob/v1.90.0/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors.go#L45
+  - record: shoot:registry_proxy_pushed_bytes_total:sum
+    expr: sum by (upstream_host) (rate(registry_proxy_pushed_bytes_total[5m]))
+  - record: shoot:registry_proxy_pulled_bytes_total:sum
+    expr: sum by (upstream_host) (rate(registry_proxy_pulled_bytes_total[5m]))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR adds recording rules to federate the `registry_proxy_pushed_bytes_total`, `registry_proxy_pulled_bytes_total` metrics in the Seed cluster's aggregate prometheus and in then also in the prometheus in the runtime cluster.

The motivation for this PR is that currently it is not possible to fetch check the above-mentioned metrics for several clusters. We only have the `Registry Cache` dashboard and we display the "delta" (pushed to clients - pulled from upstream) there. However, to conclude on the improvements by the registry-cache extensions, it would be nice to be able to fetch the metrics for given set of Shoots. For example, to be able to do queries like: fetch the "delta" for all Shoots in given Project, or fetch the "delta" for all Shoots in the landscape.



**Which issue(s) this PR fixes**:
Part of #3

**Special notes for your reviewer**:
These are the recording rules that are present in the aggregate prometheus:
![Screenshot 2024-03-12 at 15 02 03](https://github.com/gardener/gardener-extension-registry-cache/assets/9372594/40c755df-718e-469a-9750-922d7dbeeb06)

A prometheus query that can be used to fetch the "delta":
```
  (sum_over_time((shoot:registry_proxy_pushed_bytes_total:sum)[1d:1m]) * 60)
-
  (sum_over_time((shoot:registry_proxy_pulled_bytes_total:sum)[1d:1m]) * 60)
```

Many thanks to @istvanballok for the help with this task.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The registry-cache extension defines recording rules (`shoot:registry_proxy_pushed_bytes_total:sum` and `shoot:registry_proxy_pulled_bytes_total:sum`) that are federated in the Seed cluster's aggregate prometheus and also in the prometheus in the runtime cluster. These rules make possible to query registry-cache related metrics from the prometheus in the runtime cluster and in this way get an overview for given set of Shoot clusters.
```
