### PR TITLE
Upgrade the module version to 1.22.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/gardener-extension-registry-cache
 
-go 1.22.1
+go 1.22.2
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Right now, dependabot fails to create a version bump for gardener/gardener with:
```
updater | 2024/04/09 19:08:47 INFO <job_812251957> Handled error whilst updating github.com/gardener/gardener: dependency_file_not_resolvable {:message=>"go: loading module retractions for github.com/gardener/gardener@v0.32.0: module github.com/gardener/gardener@v1.92.0 requires go >= 1.22.2 (running go 1.22.1; GOTOOLCHAIN=local+auto)"}
```

In https://github.com/gardener/gardener-extension-registry-cache/pull/177, I missed to update the go module version to go 1.22.2.

When you bump the gardener/gardener version to v1.92.0 locally and then run `make tidy`, the go tool is able to deal with it and to upgrade the module version to 1.22.2:
```
% make tidy
go: module github.com/gardener/gardener@v1.92.0 requires go >= 1.22.2; switching to go1.22.2
go: upgraded go 1.22.1 => 1.22.2
# ...
```

**Which issue(s) this PR fixes**:
I hope that upgrading the go module version will resolve the dependabot failure.

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
