### PR TITLE
Limit upstream-host label value to 43 chars

### DIFF
--- a/pkg/component/registrycaches/export_test.go
+++ b/pkg/component/registrycaches/export_test.go
@@ -4,4 +4,4 @@
 
 package registrycaches
 
-var ComputeUpstreamLabel = computeUpstreamLabel
+var ComputeUpstreamLabelValue = computeUpstreamLabelValue

--- a/pkg/component/registrycaches/export_test.go
+++ b/pkg/component/registrycaches/export_test.go
@@ -4,4 +4,4 @@
 
 package registrycaches
 
-var ComputeName = computeName
+var ComputeUpstreamLabel = computeUpstreamLabel

--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -17,6 +17,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/utils"
@@ -182,8 +183,8 @@ func (r *registryCaches) computeResourcesDataForRegistryCache(ctx context.Contex
 	)
 
 	var (
-		name          = computeName(cache.Upstream)
-		upstreamLabel = strings.Replace(cache.Upstream, ":", "-", 1)
+		upstreamLabel = computeUpstreamLabel(cache.Upstream)
+		name          = "registry-" + strings.ReplaceAll(upstreamLabel, ".", "-")
 		remoteURL     = ptr.Deref(cache.RemoteURL, registryutils.GetUpstreamURL(cache.Upstream))
 		configValues  = map[string]interface{}{
 			"http_addr":       fmt.Sprintf(":%d", constants.RegistryCachePort),
@@ -262,6 +263,9 @@ func (r *registryCaches) computeResourcesDataForRegistryCache(ctx context.Contex
 			Name:      name,
 			Namespace: metav1.NamespaceSystem,
 			Labels:    getLabels(name, upstreamLabel),
+			// TODO: @dimitar-kostadinov remove the `DeleteOnInvalidUpdate` annotation in v0.10.0 release
+			// StatefulSets for upstreams with more than 43 chars will be recreated
+			Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			ServiceName: service.Name,
@@ -432,24 +436,32 @@ func getLabels(name, upstreamLabel string) map[string]string {
 	}
 }
 
-// computeName computes a name by given upstream.
-// The name later on is used by the registry cache Service, config Secret, StatefulSet and VPA.
+// computeUpstreamLabel computes upstreamLabel by given upstream.
 //
-// If length of registry-<escaped_upsteam> is NOT > 52, the name is registry-<escaped_upsteam>.
-// Otherwise it is registry-<truncated_escaped_upsteam>-<hash> where <escaped_upsteam> is truncated at 37 chars.
-// The returned name is at most 52 chars.
-func computeName(upstream string) string {
-	// The StatefulSet name limit is 63 chars. However Pods for a StatefulSet with name > 52 chars cannot be created due to https://github.com/kubernetes/kubernetes/issues/64023.
-	// The "controller-revision-hash" label gets added to the StatefulSet Pod. The label value is in format <stateful_set_name>_<hash> where <hash> is 10 or 11 chars.
-	// A label value limit is 63 chars. That's why a Pod for a StatefulSet with name > 52 chars cannot be created.
-	const statefulSetNameLimit = 52
-	escapedUpstream := strings.NewReplacer(".", "-", ":", "-").Replace(upstream)
-	name := "registry-" + escapedUpstream
-	if len(name) > statefulSetNameLimit {
-		hash := utils.ComputeSHA256Hex([]byte(upstream))[:5]
-		upstreamLimit := statefulSetNameLimit - len("registry-") - len(hash) - 1
-		name = fmt.Sprintf("registry-%s-%s", escapedUpstream[:upstreamLimit], hash)
-	}
+// Upstream is a valid DNS subdomain (RFC 1123) and optionally a port (e.g. my-registry.io[:5000])
+// It is used as a 'upstream-host' label value on registry cache resources (Service, Secret, StatefulSet and VPA).
+// Label values cannot contain ':' char, so if upstream is '<host>:<port>' the label value is transformed to '<host>-<port>'.
+// It is also used to build the resources names escaping the '.' with '-'; e.g. `registry-<escaped_upstreamLabel>`.
+//
+// Due to restrictions of resource names length, if upstream length > 43 it is truncated at 37 chars, and the
+// label value is transformed to <truncated-upstream>-<hash> where <hash> is first 5 chars of upstream sha256 hash.
+//
+// The returned upstreamLabel is at most 43 chars.
+func computeUpstreamLabel(upstream string) string {
+	// A label value length and a resource name length limits are 63 chars. However, Pods for a StatefulSet with name > 52 chars
+	// cannot be created due to https://github.com/kubernetes/kubernetes/issues/64023.
+	// The cache resources name have prefix 'registry-', thus the label value length is limited to 43.
+	const labelValueLimit = 43
 
-	return name
+	upstreamLabel := upstream
+	portIndex := strings.LastIndexByte(upstream, ':')
+	if portIndex != -1 {
+		upstreamLabel = fmt.Sprintf("%s-%s", upstream[:portIndex], upstream[portIndex+1:])
+	}
+	if len(upstream) > labelValueLimit {
+		hash := utils.ComputeSHA256Hex([]byte(upstream))[:5]
+		limit := labelValueLimit - len(hash) - 1
+		upstreamLabel = fmt.Sprintf("%s-%s", upstreamLabel[:limit], hash)
+	}
+	return upstreamLabel
 }

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -613,7 +613,7 @@ status: {}
 
 	DescribeTable("#computeUpstreamLabel",
 		func(upstream, expected string) {
-			actual := ComputeUpstreamLabel(upstream)
+			actual := ComputeUpstreamLabelValue(upstream)
 			Expect(len(actual)).NotTo(BeNumerically(">", 43))
 			Expect(actual).To(Equal(expected))
 		},

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -198,6 +198,8 @@ status:
 				out := `apiVersion: apps/v1
 kind: StatefulSet
 metadata:
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
   creationTimestamp: null
   labels:
     app: ` + name + `
@@ -609,15 +611,19 @@ status: {}
 		})
 	})
 
-	DescribeTable("#computeName",
+	DescribeTable("#computeUpstreamLabel",
 		func(upstream, expected string) {
-			actual := ComputeName(upstream)
-			Expect(len(actual)).NotTo(BeNumerically(">", 52))
+			actual := ComputeUpstreamLabel(upstream)
+			Expect(len(actual)).NotTo(BeNumerically(">", 43))
 			Expect(actual).To(Equal(expected))
 		},
 
-		Entry("short upstream", "docker.io", "registry-docker-io"),
-		Entry("long upstream", "myproj-releases.common.repositories.cloud.com", "registry-myproj-releases-common-repositories-c-3f834"),
+		Entry("short upstream", "my-registry.io", "my-registry.io"),
+		Entry("short upstream ends with port", "my-registry.io:5000", "my-registry.io-5000"),
+		Entry("short upstream ends like a port", "my-registry.io-5000", "my-registry.io-5000"),
+		Entry("long upstream", "my-very-long-registry.very-long-subdomain.io", "my-very-long-registry.very-long-subdo-2fae3"),
+		Entry("long upstream ends with port", "my-very-long-registry.long-subdomain.io:8443", "my-very-long-registry.long-subdomain.-8cb9e"),
+		Entry("long upstream ends like a port", "my-very-long-registry.long-subdomain.io-8443", "my-very-long-registry.long-subdomain.-e91ed"),
 	)
 })
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
The value of labels in Kubernetes is limited to 63 chars. The value of the `upstream-host` label is used to construct the registry cache resource names (`registry-<escaped-upstream-host-value>`) and for the StatefulSet name the limit is 52 (see #129) . To use a uniform value for both labels and component names, the `upstream-host` label value is limited to 43 chars.
Currently the remote registry host (`caches[].upstream`) is used for `upstream-host` label value. If this value is longer than 43 chars it is transformed to `<truncated-upstream>-<hash>` where `<truncated-upstream>` is the upstream truncated to 37 char and `<hash>` is the first 5 chars of `upstream` SHA256.

**Which issue(s) this PR fixes**:
Part of #3

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
The registry cache StatefulSets for registries with `upstream` host with more than 43 chars will be recreated. Only the StatefulSet will be recreated, the underlying PVC remains the same.
```
