### PR TITLE
Add validation early exit when no semantic change in providerConfig is detected

### DIFF
--- a/docs/usage/registry-cache/upstream-credentials.md
+++ b/docs/usage/registry-cache/upstream-credentials.md
@@ -73,6 +73,8 @@ To rotate registry credentials perform the following steps:
 1. Make sure that the old Secret is no longer referenced by any Shoot cluster. Finally, delete the Secret containing the old credentials (e.g., `ro-docker-secret-v1`).
 1. Delete the corresponding old credentials from the cloud provider account.
 
+> **Note**: Do not delete old Secret before the Shoot is updated with the new Secret and Shoot reconciliation is successful.
+
 ## Possible Pitfalls
 
 - The registry cache is not protected by any authentication/authorization mechanism. The cached images (incl. private images) can be fetched from the registry cache without authentication/authorization. Note that the registry cache itself is not exposed publicly.

--- a/docs/usage/registry-cache/upstream-credentials.md
+++ b/docs/usage/registry-cache/upstream-credentials.md
@@ -63,6 +63,8 @@ This document describe how to supply credentials for the private upstream regist
    # ...
    ```
 
+> **Note**: Do not delete the referenced Secret when there is a Shoot still using it.
+
 ## How to rotate the registry credentials?
 
 To rotate registry credentials perform the following steps:
@@ -72,8 +74,6 @@ To rotate registry credentials perform the following steps:
 1. The above step will trigger a Shoot reconciliation. Wait for it to complete.
 1. Make sure that the old Secret is no longer referenced by any Shoot cluster. Finally, delete the Secret containing the old credentials (e.g., `ro-docker-secret-v1`).
 1. Delete the corresponding old credentials from the cloud provider account.
-
-> **Note**: Do not delete old Secret before the Shoot is updated with the new Secret and Shoot reconciliation is successful.
 
 ## Possible Pitfalls
 

--- a/pkg/admission/validator/cache/shoot.go
+++ b/pkg/admission/validator/cache/shoot.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -82,6 +83,10 @@ func (s *shoot) Validate(ctx context.Context, new, old client.Object) error {
 			oldRegistryConfig := &api.RegistryConfig{}
 			if err := runtime.DecodeInto(s.decoder, oldExt.ProviderConfig.Raw, oldRegistryConfig); err != nil {
 				return fmt.Errorf("failed to decode providerConfig: %w", err)
+			}
+
+			if equality.Semantic.DeepEqual(registryConfig, oldRegistryConfig) {
+				return nil
 			}
 
 			allErrs = append(allErrs, validation.ValidateRegistryConfigUpdate(oldRegistryConfig, registryConfig, providerConfigPath)...)

--- a/pkg/admission/validator/cache/shoot_test.go
+++ b/pkg/admission/validator/cache/shoot_test.go
@@ -227,6 +227,26 @@ var _ = Describe("Shoot validator", func() {
 					"Detail":   Equal("field is immutable"),
 				}))))
 			})
+
+			It("should exit earlier when no semantic change in providerConfig is detected", func() {
+				shoot.Spec.Extensions[0].ProviderConfig = &runtime.RawExtension{
+					Raw: encode(&v1alpha3.RegistryConfig{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: v1alpha3.SchemeGroupVersion.String(),
+						},
+						Caches: []v1alpha3.RegistryCache{},
+					}),
+				}
+				oldShoot.Spec.Extensions[0].ProviderConfig = &runtime.RawExtension{
+					Raw: encode(&v1alpha3.RegistryConfig{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: v1alpha3.SchemeGroupVersion.String(),
+						},
+						Caches: nil,
+					}),
+				}
+				Expect(shootValidator.Validate(ctx, shoot, oldShoot)).To(Succeed())
+			})
 		})
 
 		Context("Upstream credentials", func() {

--- a/pkg/admission/validator/cache/shoot_test.go
+++ b/pkg/admission/validator/cache/shoot_test.go
@@ -233,16 +233,29 @@ var _ = Describe("Shoot validator", func() {
 					Raw: encode(&v1alpha3.RegistryConfig{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: v1alpha3.SchemeGroupVersion.String(),
+							Kind:       "RegistryConfig",
 						},
-						Caches: []v1alpha3.RegistryCache{},
+						Caches: []v1alpha3.RegistryCache{
+							{
+								Upstream: "https://registry.example.com", // invalid upstream
+							},
+						},
 					}),
 				}
 				oldShoot.Spec.Extensions[0].ProviderConfig = &runtime.RawExtension{
 					Raw: encode(&v1alpha3.RegistryConfig{
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: v1alpha3.SchemeGroupVersion.String(),
+							Kind:       "RegistryConfig",
 						},
-						Caches: nil,
+						Caches: []v1alpha3.RegistryCache{
+							{
+								Upstream: "https://registry.example.com", // invalid upstream
+								GarbageCollection: &v1alpha3.GarbageCollection{
+									TTL: v1alpha3.DefaultTTL,
+								},
+							},
+						},
 					}),
 				}
 				Expect(shootValidator.Validate(ctx, shoot, oldShoot)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Adds validation early exit when no semantic change in providerConfig is detected. This way the redundant validation checks are skipped, the performance is improved and the possibility of blocking reconciliation or deleting the Shoot is minimized.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The registry-cache admission validation is skipped when no semantic change in `providerConfig` is detected.
```
