### PR TITLE
e2e && tm tests: Increase ginkgo timeouts

### DIFF
--- a/.test-defs/TestSuiteRegistryCacheBetaSerial.yaml
+++ b/.test-defs/TestSuiteRegistryCacheBetaSerial.yaml
@@ -21,5 +21,6 @@ spec:
       -shoot-name=$SHOOT_NAME
       -ginkgo.focus="\[BETA\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
+      -ginkgo.timeout=9000s
 
   image: golang:1.22.5

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -46,4 +46,4 @@ else
   fi
 fi
 
-GO111MODULE=on ginkgo run --timeout=1h --v --show-node-events "$@"
+GO111MODULE=on ginkgo run --timeout=1h30m --v --show-node-events "$@"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
ginkgo's default timeout is `1h`:
```
  --timeout [duration] (default: 1h)
    Test suite fails if it does not complete within the specified timeout.
```

Running `make test-e2e-local PARALLEL_E2E_TESTS=1` locally is likely to time out:
```
Summarizing 1 Failure:
  [TIMEDOUT] Registry Cache Extension Tests [It] should create Shoot, enable extension, add upstream, remove upstream, disable extension, delete Shoot [cache]
  /go/src/github.com/gardener/gardener-extension-registry-cache/test/e2e/cache/create_enable_add_remove_disable_delete.go:27

Ran 5 of 5 Specs in 3588.601 seconds
FAIL! - Suite Timeout Elapsed -- 4 Passed | 1 Failed | 0 Pending | 0 Skipped
--- FAIL: TestE2E (3588.60s)
FAIL

Ginkgo ran 1 suite in 1h0m1.547318958s

Test Suite Failed
make: *** [test-e2e-local] Error 1
```

The first commit increases the timeout for the e2e tests.
The second one does this for the tm tests: similar to a change in https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/127.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
