### PR TITLE
Make helmchart `image` equal to other gardener extensions.

### DIFF
--- a/charts/gardener-extension-registry-cache/templates/_helpers.tpl
+++ b/charts/gardener-extension-registry-cache/templates/_helpers.tpl
@@ -7,6 +7,14 @@ apiVersion: config.registry.extensions.gardener.cloud/v1alpha1
 kind: Configuration
 {{- end }}
 
+{{-  define "image" -}}
+  {{- if hasPrefix "sha256:" .Values.image.tag }}
+  {{- printf "%s@%s" .Values.image.repository .Values.image.tag }}
+  {{- else }}
+  {{- printf "%s:%s" .Values.image.repository .Values.image.tag }}
+  {{- end }}
+{{- end }}
+
 {{- define "leaderelectionid" -}}
 extension-registry-cache-leader-election
 {{- end -}}

--- a/charts/gardener-extension-registry-cache/templates/deployment.yaml
+++ b/charts/gardener-extension-registry-cache/templates/deployment.yaml
@@ -39,8 +39,8 @@ spec:
       serviceAccountName: gardener-extension-registry-cache
       containers:
       - name: gardener-extension-registry-cache
-        image: {{ .Values.image }}
-        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        image: {{ include "image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - --config=/etc/registry-cache/config.yaml
         - --max-concurrent-reconciles={{ .Values.controllers.extension.concurrentSyncs }}

--- a/charts/gardener-extension-registry-cache/values.yaml
+++ b/charts/gardener-extension-registry-cache/values.yaml
@@ -1,5 +1,7 @@
-image: europe-docker.pkg.dev/gardener-project/public/gardener/extensions/registry-cache:latest
-imagePullPolicy: IfNotPresent
+image:
+  repository: europe-docker.pkg.dev/gardener-project/public/gardener/extensions/registry-cache
+  tag: latest
+  pullPolicy: IfNotPresent
 
 replicaCount: 1
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR allows the helm chart `image` to be configured like any other gardener extension. Not sure why it was different in the first place. 
For example [gardener-extension-os-ubuntu](https://github.com/gardener/gardener-extension-os-ubuntu/blob/bb20d74633e6bfdcbd1901246951f850f7842e6f/charts/gardener-extension-os-ubuntu/values.yaml#L1) or [gardener-extension-provider-gcp](https://github.com/gardener/gardener-extension-provider-gcp/blob/4a916b4f0012528f35f503e2a4dc25c631e18a8e/charts/gardener-extension-provider-gcp/values.yaml#L1) are configured to accept a separate `registry` and `tag` instead of `image` with registry and tag.

It was this way before, but destroyed here https://github.com/gardener/gardener-extension-registry-cache/commit/a73babe7fd7a8e707d9d9667ad2cbbaafc1b0d1a

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
