### PR TITLE
Add optional highAvailability feature for registry cache

### DIFF
--- a/docs/usage/registry-cache/configuration.md
+++ b/docs/usage/registry-cache/configuration.md
@@ -92,6 +92,8 @@ The `providerConfig.caches[].garbageCollection.ttl` field is the time to live of
 
 The `providerConfig.caches[].secretReferenceName` is the name of the reference for the Secret containing the upstream registry credentials. To cache images from a private registry, credentials to the upstream registry should be supplied. For more details, see [How to provide credentials for upstream registry](upstream-credentials.md#how-to-provide-credentials-for-upstream-registry).
 
+The `providerConfig.caches[].highAvailability` defines if the StatefulSet is scaled to 2 replicas. See [Increase the cache disk size](#high-availability) for more information.
+
 > **Note**: It is only possible to provide one set of credentials for one private upstream registry.
 
 ## Garbage Collection
@@ -139,7 +141,9 @@ There is always the option to remove the cache from the Shoot spec and to readd 
 
 ## High Аvailability
 
-The registry cache runs with a single replica. This fact may lead to concerns for the high availability such as "What happens when the registry cache is down? Does containerd fail to pull the image?". As outlined in the [How does it work? section](#how-does-it-work), containerd is configured to fall back to the upstream registry if it fails to pull the image from the registry cache. Hence, when the registry cache is unavailable, the containerd's image pull operations are not affected because containerd falls back to image pull from the upstream registry.
+Per default the registry cache runs with a single replica. This fact may lead to concerns for the high availability such as "What happens when the registry cache is down? Does containerd fail to pull the image?". As outlined in the [How does it work? section](#how-does-it-work), containerd is configured to fall back to the upstream registry if it fails to pull the image from the registry cache. Hence, when the registry cache is unavailable, the containerd's image pull operations are not affected because containerd falls back to image pull from the upstream registry.
+
+In special cases where this is not enough (for example when using the registry cache with a proxy) it is possible to set `providerConfig.caches[].highAvailability` to `true`, this will add the label `high-availability-config.resources.gardener.cloud/type=server` and scale the statefulset to 2 replicas. The `topologySpreadConstraints` is added according to the cluster configuration. See also [High Availability of Deployed Components](https://gardener.cloud/docs/gardener/high-availability/#system-components).
 
 ## Possible Pitfalls
 

--- a/hack/api-reference/registry.md
+++ b/hack/api-reference/registry.md
@@ -129,6 +129,18 @@ string
 <p>SecretReferenceName is the name of the reference for the Secret containing the upstream registry credentials.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>highAvailability</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>HighAvailability defines if the StatefulSet is scaled with the <a href="https://gardener.cloud/docs/gardener/high-availability/#system-components">High Availability</a> feature.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="registry.extensions.gardener.cloud/v1alpha3.RegistryCacheStatus">RegistryCacheStatus

--- a/pkg/apis/registry/types.go
+++ b/pkg/apis/registry/types.go
@@ -38,6 +38,8 @@ type RegistryCache struct {
 	GarbageCollection *GarbageCollection
 	// SecretReferenceName is the name of the reference for the Secret containing the upstream registry credentials
 	SecretReferenceName *string
+	// HighAvailability defines if the StatefulSet is scaled with the [High Availability](https://gardener.cloud/docs/gardener/high-availability/#system-components) feature.
+	HighAvailability *bool
 }
 
 // Volume contains settings for the registry cache volume.

--- a/pkg/apis/registry/v1alpha3/types.go
+++ b/pkg/apis/registry/v1alpha3/types.go
@@ -43,6 +43,9 @@ type RegistryCache struct {
 	// SecretReferenceName is the name of the reference for the Secret containing the upstream registry credentials.
 	// +optional
 	SecretReferenceName *string `json:"secretReferenceName,omitempty"`
+	// HighAvailability defines if the StatefulSet is scaled with the [High Availability](https://gardener.cloud/docs/gardener/high-availability/#system-components) feature.
+	// +optional
+	HighAvailability *bool `json:"highAvailability,omitempty"`
 }
 
 // Volume contains settings for the registry cache volume.

--- a/pkg/apis/registry/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/registry/v1alpha3/zz_generated.conversion.go
@@ -113,6 +113,7 @@ func autoConvert_v1alpha3_RegistryCache_To_registry_RegistryCache(in *RegistryCa
 	out.Volume = (*registry.Volume)(unsafe.Pointer(in.Volume))
 	out.GarbageCollection = (*registry.GarbageCollection)(unsafe.Pointer(in.GarbageCollection))
 	out.SecretReferenceName = (*string)(unsafe.Pointer(in.SecretReferenceName))
+	out.HighAvailability = (*bool)(unsafe.Pointer(in.HighAvailability))
 	return nil
 }
 
@@ -127,6 +128,7 @@ func autoConvert_registry_RegistryCache_To_v1alpha3_RegistryCache(in *registry.R
 	out.Volume = (*Volume)(unsafe.Pointer(in.Volume))
 	out.GarbageCollection = (*GarbageCollection)(unsafe.Pointer(in.GarbageCollection))
 	out.SecretReferenceName = (*string)(unsafe.Pointer(in.SecretReferenceName))
+	out.HighAvailability = (*bool)(unsafe.Pointer(in.HighAvailability))
 	return nil
 }
 

--- a/pkg/apis/registry/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/registry/v1alpha3/zz_generated.deepcopy.go
@@ -52,6 +52,11 @@ func (in *RegistryCache) DeepCopyInto(out *RegistryCache) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.HighAvailability != nil {
+		in, out := &in.HighAvailability, &out.HighAvailability
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/registry/zz_generated.deepcopy.go
+++ b/pkg/apis/registry/zz_generated.deepcopy.go
@@ -52,6 +52,11 @@ func (in *RegistryCache) DeepCopyInto(out *RegistryCache) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.HighAvailability != nil {
+		in, out := &in.HighAvailability, &out.HighAvailability
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -17,6 +17,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/gardener/gardener/pkg/utils"
@@ -104,8 +105,8 @@ func (r *registryCaches) Deploy(ctx context.Context) error {
 
 		secretName, secret = managedresources.NewSecret(r.client, r.namespace, managedResourceName, data, false)
 		managedResource    = managedresources.NewForShoot(r.client, r.namespace, managedResourceName, constants.Origin, keepObjects).
-					WithSecretRef(secretName).
-					DeletePersistentVolumeClaims(true)
+			WithSecretRef(secretName).
+			DeletePersistentVolumeClaims(true)
 	)
 
 	if err := secret.Reconcile(ctx); err != nil {
@@ -257,11 +258,16 @@ func (r *registryCaches) computeResourcesDataForRegistryCache(ctx context.Contex
 		},
 	}
 
+	additionalStatefulSetLabels := map[string]string{}
+	if cache.HighAvailability != nil && *cache.HighAvailability {
+		additionalStatefulSetLabels[v1alpha1.HighAvailabilityConfigType] = v1alpha1.HighAvailabilityConfigTypeServer
+	}
+
 	statefulSet := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: metav1.NamespaceSystem,
-			Labels:    getLabels(name, upstreamLabel),
+			Labels:    utils.MergeStringMaps(getLabels(name, upstreamLabel), additionalStatefulSetLabels),
 		},
 		Spec: appsv1.StatefulSetSpec{
 			ServiceName: service.Name,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind enhancement

**What this PR does / why we need it**:

This PR adds the optional `highAvailability` setting for the proxy cache. As mentioned in #246 in some cases the registry cache becomes more critical (like the proxy use case). In such cases it makes sense to scale the registry cache to more replicas. This PR uses the [High Availability of Deployed Components](https://gardener.cloud/docs/gardener/high-availability/#system-components) feature to also set a working `topologySpreadConstraints`.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```user feature
Add optional setting for a registry cache to scale the `StatefulSet` to 2 replicas with the [High Availability of Deployed Components](https://gardener.cloud/docs/gardener/high-availability/#system-components) feature.
```
