### PR TITLE
pipeline_definitions: Don't build and push images and charts on pull requests

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -66,16 +66,6 @@ gardener-extension-registry-cache:
           - *registry-cache
           - *registry-cache-admission-application
           - *registry-cache-admission-runtime
-    pull-request:
-      traits:
-        pull-request: ~
-        options:
-          public_build_logs: true
-        publish:
-          helmcharts:
-          - *registry-cache
-          - *registry-cache-admission-application
-          - *registry-cache-admission-runtime
     release:
       steps:
         verify:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind cleanup

**What this PR does / why we need it**:
After https://github.com/gardener/gardener-extension-registry-cache/pull/229 we noticed that we unnecessary build and push images and charts on pull requests. This PR adapts the extension to be like the gardener/gardener repo: there is already a prow job on PRs and builds the images without pushing it.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
