### PR TITLE
Clean up usages of the already removed `shoot.gardener.cloud/infrastructure-cleanup-wait-period-seconds` annotation

### DIFF
--- a/example/shoot-registry-cache.yaml
+++ b/example/shoot-registry-cache.yaml
@@ -4,7 +4,6 @@ metadata:
   name: local
   namespace: garden-local
   annotations:
-    shoot.gardener.cloud/infrastructure-cleanup-wait-period-seconds: "0"
     shoot.gardener.cloud/cloud-config-execution-max-delay-seconds: "0"
 spec:
   seedName: local

--- a/example/shoot-registry-cache.yaml
+++ b/example/shoot-registry-cache.yaml
@@ -7,7 +7,8 @@ metadata:
     shoot.gardener.cloud/cloud-config-execution-max-delay-seconds: "0"
 spec:
   seedName: local
-  cloudProfileName: local
+  cloudProfile:
+    name: local
   secretBindingName: local # dummy, doesn't contain any credentials
   region: local
   purpose: testing

--- a/example/shoot-registry-mirror.yaml
+++ b/example/shoot-registry-mirror.yaml
@@ -4,7 +4,6 @@ metadata:
   name: local
   namespace: garden-local
   annotations:
-    shoot.gardener.cloud/infrastructure-cleanup-wait-period-seconds: "0"
     shoot.gardener.cloud/cloud-config-execution-max-delay-seconds: "0"
 spec:
   seedName: local

--- a/example/shoot-registry-mirror.yaml
+++ b/example/shoot-registry-mirror.yaml
@@ -7,7 +7,8 @@ metadata:
     shoot.gardener.cloud/cloud-config-execution-max-delay-seconds: "0"
 spec:
   seedName: local
-  cloudProfileName: local
+  cloudProfile:
+    name: local
   secretBindingName: local # dummy, doesn't contain any credentials
   region: local
   purpose: testing


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
The annotation was removed in Gardener v1.94.0 with https://github.com/gardener/gardener/pull/9632.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
