### PR TITLE
Enable gosec for static application security testing

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -34,6 +34,13 @@ gardener-extension-registry-cache:
         attribute: global.image.tag
 
   base_definition:
+    repo:
+      source_labels:
+      - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1
+        value:
+          policy: skip
+          comment: |
+            We use gosec for sast scanning, see attached log.
     traits:
       version:
         preprocess: 'inject-commit-hash'
@@ -79,6 +86,16 @@ gardener-extension-registry-cache:
           nextversion: 'bump_minor'
           next_version_callback: '.ci/prepare_release'
           release_callback: '.ci/prepare_release'
+          assets:
+          - type: build-step-log
+            step_name: verify
+            purposes:
+            - lint
+            - sast
+            - gosec
+            comment: |
+              We use gosec (linter) for SAST scans, see: https://github.com/securego/gosec.
+              Enabled by https://github.com/gardener/gardener-extension-registry-cache/pull/272
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ TODO
 .go-version
 
 /gardener
+
+# gosec
+gosec-report.sarif

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,14 @@ generate-in-docker:
 format: $(GOIMPORTS) $(GOIMPORTSREVISER)
 	@bash $(GARDENER_HACK_DIR)/format.sh ./cmd ./pkg ./test
 
+.PHONY: sast
+sast: tidy $(GOSEC)
+	@bash $(GARDENER_HACK_DIR)/sast.sh
+
+.PHONY: sast-report
+sast-report: tidy $(GOSEC)
+	@bash $(GARDENER_HACK_DIR)/sast.sh --gosec-report true
+
 .PHONY: test
 test:
 	@bash $(GARDENER_HACK_DIR)/test.sh ./cmd/... ./pkg/...
@@ -103,10 +111,10 @@ test-clean:
 	@bash $(GARDENER_HACK_DIR)/test-cover-clean.sh
 
 .PHONY: verify
-verify: check format test
+verify: check format test sast
 
 .PHONY: verify-extended
-verify-extended: check-generate check format test-cov test-clean
+verify-extended: check-generate check format test-cov test-clean sast-report
 
 test-e2e-local: $(GINKGO)
 	./hack/test-e2e-local.sh --procs=$(PARALLEL_E2E_TESTS) ./test/e2e/...

--- a/Makefile
+++ b/Makefile
@@ -91,12 +91,12 @@ format: $(GOIMPORTS) $(GOIMPORTSREVISER)
 	@bash $(GARDENER_HACK_DIR)/format.sh ./cmd ./pkg ./test
 
 .PHONY: sast
-sast: tidy $(GOSEC)
+sast: $(GOSEC)
 	@bash $(GARDENER_HACK_DIR)/sast.sh
 
 .PHONY: sast-report
-sast-report: tidy $(GOSEC)
-	@bash $(GARDENER_HACK_DIR)/sast.sh --gosec-report true
+sast-report: $(GOSEC)
+	@bash $(GARDENER_HACK_DIR)/sast.sh --gosec-report true --report-dir $(REPO_ROOT)
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,11 @@ format: $(GOIMPORTS) $(GOIMPORTSREVISER)
 
 .PHONY: sast
 sast: $(GOSEC)
-	@bash $(GARDENER_HACK_DIR)/sast.sh --exclude-dirs gardener,hack
+	@bash $(GARDENER_HACK_DIR)/sast.sh --exclude-dirs hack,gardener
 
 .PHONY: sast-report
 sast-report: $(GOSEC)
-	@bash $(GARDENER_HACK_DIR)/sast.sh --exclude-dirs gardener,hack --gosec-report true --report-dir $(REPO_ROOT)
+	@bash $(GARDENER_HACK_DIR)/sast.sh --exclude-dirs hack,gardener --gosec-report true
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,11 @@ format: $(GOIMPORTS) $(GOIMPORTSREVISER)
 
 .PHONY: sast
 sast: $(GOSEC)
-	@bash $(GARDENER_HACK_DIR)/sast.sh
+	@bash $(GARDENER_HACK_DIR)/sast.sh --exclude-dirs gardener,hack
 
 .PHONY: sast-report
 sast-report: $(GOSEC)
-	@bash $(GARDENER_HACK_DIR)/sast.sh --gosec-report true --report-dir $(REPO_ROOT)
+	@bash $(GARDENER_HACK_DIR)/sast.sh --exclude-dirs gardener,hack --gosec-report true --report-dir $(REPO_ROOT)
 
 .PHONY: test
 test:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance
/kind enhancement

**What this PR does / why we need it**:
This PR enables gosec following https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/189

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-registry-cache/issues/269

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
`gosec` is made available for SAST(static application security testing). It can be run with `make sast` or `make sast-report`, but is also incorporated in the `verify` and `verify-extended` makefile targets. 
```
