### PR TITLE
Fix `make extension-up`

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: skaffold/v4beta3
+apiVersion: skaffold/v4beta7
 kind: Config
 metadata:
   name: extension
@@ -60,7 +60,7 @@ deploy:
         - --server-side
         - --force-conflicts
 ---
-apiVersion: skaffold/v4beta3
+apiVersion: skaffold/v4beta7
 kind: Config
 metadata:
   name: admission

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -49,7 +49,16 @@ manifests:
     paths:
     - local-setup
 deploy:
-  kubectl: {}
+  # --server-side apply is a workaround for https://github.com/gardener/gardener/issues/10267.
+  # kubectl apply attempts a strategic merge patch which fails for a ControllerDeployment.
+  # For more details, see https://github.com/gardener/gardener/issues/10267.
+  #
+  # TODO: Switch back to "kubectl: {}" when the above issue is resolved.
+  kubectl:
+    flags:
+      apply:
+        - --server-side
+        - --force-conflicts
 ---
 apiVersion: skaffold/v4beta3
 kind: Config


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
See more details in https://github.com/gardener/gardener-extension-registry-cache/issues/276 and in the comment in the `skaffold.yaml` file.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-registry-cache/issues/276

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
An issue causing `make extension-up` to fail to patch the ControllerDeployment is now mitigated.
```
