### PR TITLE
Fix skaffold tag generation to generate a new tag on code changes (without local commit)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ ci-e2e-kind:
 export SKAFFOLD_BUILD_CONCURRENCY = 0
 extension-up extension-dev: export SKAFFOLD_DEFAULT_REPO = garden.local.gardener.cloud:5001
 extension-up extension-dev: export SKAFFOLD_PUSH = true
+extension-up extension-dev: export EXTENSION_VERSION = $(VERSION)
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
 extension-up extension-dev extension-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=extension-local
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,6 +6,15 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
+  tagPolicy:
+    customTemplate:
+      template: "{{.version}}-{{.sha}}"
+      components:
+        - name: version
+          envTemplate:
+            template: "{{.EXTENSION_VERSION}}"
+        - name: sha
+          inputDigest: {}
   artifacts:
     - image: local-skaffold/gardener-extension-registry-cache
       ko:
@@ -58,6 +67,15 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
+  tagPolicy:
+    customTemplate:
+      template: "{{.version}}-{{.sha}}"
+      components:
+        - name: version
+          envTemplate:
+            template: "{{.EXTENSION_VERSION}}"
+        - name: sha
+          inputDigest: {}
   artifacts:
     - image: local-skaffold/gardener-extension-registry-cache-admission
       ko:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
See https://github.com/gardener/gardener-extension-registry-cache/issues/278

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-registry-cache/issues/278

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
An issue causing `make extension-up` to do NOT generate a new tag for local source code changes is now fixed.
```
