### PR TITLE
skaffold: Remove custom `tagPolicy` for the admission

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -13,6 +13,8 @@ build:
         - name: version
           envTemplate:
             template: "{{.EXTENSION_VERSION}}"
+        # inputDigest is used to inject a digest of the artifact source into the built image tag
+        # and therefore into the SKAFFOLD_IMAGE environment variable which is used when generating the corresponding ControllerDeployment
         - name: sha
           inputDigest: {}
   artifacts:
@@ -76,15 +78,6 @@ metadata:
 build:
   insecureRegistries:
     - garden.local.gardener.cloud:5001
-  tagPolicy:
-    customTemplate:
-      template: "{{.version}}-{{.sha}}"
-      components:
-        - name: version
-          envTemplate:
-            template: "{{.EXTENSION_VERSION}}"
-        - name: sha
-          inputDigest: {}
   artifacts:
     - image: local-skaffold/gardener-extension-registry-cache-admission
       ko:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
In https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/194#discussion_r1848606461 @plkokanov found that we don't need a custom `tagPolicy` for the admission.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-registry-cache/pull/279

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
