### PR TITLE
Increase the `e2e-cache-ssc` e2e test create shoot context timeout to 15 minutes

### DIFF
--- a/test/e2e/cache/create_enabled_delete_shoot_system_components.go
+++ b/test/e2e/cache/create_enabled_delete_shoot_system_components.go
@@ -35,7 +35,8 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 		// Use 10min as timeout to verify that we don't have a Node bootstrap issue.
 		// https://github.com/gardener/gardener-extension-registry-cache/pull/68 fixes the Node bootstrap issue
 		// and this tests verifies that the scenario does not regress.
-		ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
+		// Mitigate https://github.com/gardener/gardener-extension-registry-cache/issues/290 by increasing context timeout to 15min
+		ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
 		defer cancel()
 		Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 		f.Verify()

--- a/test/e2e/cache/create_enabled_delete_shoot_system_components.go
+++ b/test/e2e/cache/create_enabled_delete_shoot_system_components.go
@@ -35,7 +35,9 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 		// Use 10min as timeout to verify that we don't have a Node bootstrap issue.
 		// https://github.com/gardener/gardener-extension-registry-cache/pull/68 fixes the Node bootstrap issue
 		// and this tests verifies that the scenario does not regress.
-		// Mitigate https://github.com/gardener/gardener-extension-registry-cache/issues/290 by increasing context timeout to 15min
+		//
+		// Mitigate https://github.com/gardener/gardener-extension-registry-cache/issues/290 by increasing context timeout to 15min to prevent flakes.
+		// TODO(dimitar-kostadinov): Fix https://github.com/gardener/gardener-extension-registry-cache/issues/290 in a permanent way.
 		ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
 		defer cancel()
 		Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Increase the context timeout of `Create Shoot` step in `e2e-cache-ssc` e2e test to 15 minutes.

**Which issue(s) this PR fixes**:
Mitigate #290 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
