### PR TITLE
Rework the component unit tests to use the managedResourceObjectsMatcher

### DIFF
--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -277,7 +277,7 @@ func (r *registryCaches) computeResourcesDataForRegistryCache(ctx context.Contex
 			Selector: &metav1.LabelSelector{
 				MatchLabels: getLabels(name, upstreamLabel),
 			},
-			Replicas: ptr.To(int32(1)),
+			Replicas: ptr.To[int32](1),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: utils.MergeStringMaps(getLabels(name, upstreamLabel), map[string]string{
@@ -407,7 +407,6 @@ source /entrypoint.sh /etc/distribution/config.yml
 								corev1.ResourceStorage: *cache.Volume.Size,
 							},
 						},
-
 						StorageClassName: storageClassName,
 					},
 				},
@@ -432,8 +431,6 @@ source /entrypoint.sh /etc/distribution/config.yml
 
 	var vpa *vpaautoscalingv1.VerticalPodAutoscaler
 	if r.values.VPAEnabled {
-		updateMode := vpaautoscalingv1.UpdateModeAuto
-		controlledValues := vpaautoscalingv1.ContainerControlledValuesRequestsOnly
 		vpa = &vpaautoscalingv1.VerticalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -446,13 +443,13 @@ source /entrypoint.sh /etc/distribution/config.yml
 					Name:       name,
 				},
 				UpdatePolicy: &vpaautoscalingv1.PodUpdatePolicy{
-					UpdateMode: &updateMode,
+					UpdateMode: ptr.To(vpaautoscalingv1.UpdateModeAuto),
 				},
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 						{
 							ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
-							ControlledValues: &controlledValues,
+							ControlledValues: ptr.To(vpaautoscalingv1.ContainerControlledValuesRequestsOnly),
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("20Mi"),
 							},

--- a/test/e2e/cache/create_enable_for_private_registry_delete.go
+++ b/test/e2e/cache/create_enable_for_private_registry_delete.go
@@ -222,7 +222,7 @@ func deployUpstreamRegistry(ctx context.Context, f *framework.ShootCreationFrame
 					"app": "test-registry",
 				},
 			},
-			Replicas: ptr.To(int32(1)),
+			Replicas: ptr.To[int32](1),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -51,8 +51,8 @@ func DefaultShoot(generateName string) *gardencorev1beta1.Shoot {
 				Version: "1.31.1",
 				Kubelet: &gardencorev1beta1.KubeletConfig{
 					SerializeImagePulls: ptr.To(false),
-					RegistryPullQPS:     ptr.To(int32(10)),
-					RegistryBurst:       ptr.To(int32(20)),
+					RegistryPullQPS:     ptr.To[int32](10),
+					RegistryBurst:       ptr.To[int32](20),
 				},
 				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
The `managedResourceObjectsMatcher` is introduced with https://github.com/gardener/gardener/pull/9964 in `gardener/gardener@v1.98.0`. We had an item in our backlog to evaluate it and potentially start using it.
The managedResourceObjectsMatcher:
- reduces some boilerplate - we no longer need to fetch the ManagedResource Secret, then uncompress and decode it to fetch the manifest inside
- we can pass native go types for the expected resources instead of serialized YAML manifests. The YAML manifests are sensitive to whitespace and key order.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
