### PR TITLE
Improve the check for Node bootstrap issue

### DIFF
--- a/test/e2e/cache/create_enable_for_private_registry_delete.go
+++ b/test/e2e/cache/create_enable_for_private_registry_delete.go
@@ -155,9 +155,6 @@ func addPrivateRegistrySecret(shoot *gardencorev1beta1.Shoot) {
 
 // deployUpstreamRegistry deploy test upstream registry and return the <host:port> to it
 func deployUpstreamRegistry(ctx context.Context, f *framework.ShootCreationFramework, password string) (upstreamHostPort string) {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-	defer cancel()
-
 	// Create htpasswd Secret
 	encryptedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())

--- a/test/e2e/cache/create_enabled_delete_shoot_system_components.go
+++ b/test/e2e/cache/create_enabled_delete_shoot_system_components.go
@@ -74,5 +74,5 @@ func verifyNoTimeoutLogsInContainerd(ctx context.Context, logger logr.Logger, sh
 	// and this test verifies that the scenario does not regress.
 	output, err := rootPodExecutor.Execute(ctx, []string{"sh", "-c", `journalctl -u containerd | grep -E "msg=\"trying next host\" error=\"failed to do request: Head .+ i/o timeout\"" || test $? = 1`}...)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	Expect(string(output)).To(BeEmpty())
+	ExpectWithOffset(1, string(output)).To(BeEmpty())
 }

--- a/test/e2e/cache/create_enabled_delete_shoot_system_components.go
+++ b/test/e2e/cache/create_enabled_delete_shoot_system_components.go
@@ -8,9 +8,12 @@ import (
 	"context"
 	"time"
 
+	"github.com/gardener/gardener/test/framework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
@@ -32,16 +35,29 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 
 	It("should create Shoot with registry-cache extension enabled with caches for Shoot system components, delete Shoot", func() {
 		By("Create Shoot")
-		// Use 10min as timeout to verify that we don't have a Node bootstrap issue.
-		// https://github.com/gardener/gardener-extension-registry-cache/pull/68 fixes the Node bootstrap issue
-		// and this tests verifies that the scenario does not regress.
-		//
-		// Mitigate https://github.com/gardener/gardener-extension-registry-cache/issues/290 by increasing context timeout to 15min to prevent flakes.
-		// TODO(dimitar-kostadinov): Fix https://github.com/gardener/gardener-extension-registry-cache/issues/290 in a permanent way.
 		ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
 		defer cancel()
 		Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 		f.Verify()
+
+		By("Make sure there is no I/O timeout during containerd image pulls")
+		ctx, cancel = context.WithTimeout(parentCtx, 3*time.Minute)
+		defer cancel()
+
+		nodeList, err := framework.GetAllNodesInWorkerPool(ctx, f.ShootFramework.ShootClient, ptr.To("local"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(nodeList.Items)).To(BeNumerically(">=", 1), "Expected to find at least one Node in the cluster")
+
+		rootPodExecutor := framework.NewRootPodExecutor(f.Logger, f.ShootFramework.ShootClient, &nodeList.Items[0].Name, metav1.NamespaceSystem)
+		defer func(ctx context.Context, rootPodExecutor framework.RootPodExecutor) {
+			_ = rootPodExecutor.Clean(ctx)
+		}(ctx, rootPodExecutor)
+		// Make sure we don't have a Node bootstrap issue, i.e. there is no I/O timeout during image pull in the containerd logs.
+		// https://github.com/gardener/gardener-extension-registry-cache/pull/68 fixes the Node bootstrap issue
+		// and this tests verifies that the scenario does not regress.
+		output, err := rootPodExecutor.Execute(ctx, []string{"sh", "-c", `journalctl -u containerd | grep -E "msg=\"trying next host\" error=\"failed to do request: Head .+ i/o timeout\"" || test $? = 1`}...)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(output)).To(BeEmpty())
 
 		By("[europe-docker.pkg.dev] Verify registry-cache works")
 		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootFramework.ShootClient, common.ArtifactRegistryNginx1176Image)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Improving the check for Node bootstrap issue. Now containerd logs are checked for I/O timeout errors during image pull.

**Which issue(s) this PR fixes**:
Fixes #290 

**Special notes for your reviewer**:
Depends on https://github.com/gardener/gardener/pull/11010 and/or https://github.com/gardener/gardener/pull/11008

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
