### PR TITLE
Fix a cyrillic character in the header

### DIFF
--- a/docs/usage/registry-cache/configuration.md
+++ b/docs/usage/registry-cache/configuration.md
@@ -143,7 +143,7 @@ There is always the option to remove the cache from the Shoot spec and to readd 
 
 > Drawback of this approach: The already cached images get lost and the cache starts with an empty disk.
 
-## High Аvailability
+## High Availability
 
 The registry cache runs with a single replica. This fact may lead to concerns for the high availability such as "What happens when the registry cache is down? Does containerd fail to pull the image?". As outlined in the [How does it work? section](#how-does-it-work), containerd is configured to fall back to the upstream registry if it fails to pull the image from the registry cache. Hence, when the registry cache is unavailable, the containerd's image pull operations are not affected because containerd falls back to image pull from the upstream registry.
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
Right now, the `А` in https://github.com/gardener/gardener-extension-registry-cache/blob/4b9368c6f417fd6bf383d7965b8350aaafde503d/docs/usage/registry-cache/configuration.md?plain=1#L146 is the cyrillic `А` and not the English one. This PR fixes it to use the English `A`.

Introduced with https://github.com/gardener/gardener-extension-registry-cache/commit/9176c6572d582e0725024b1db30735d8c7f25cbc (cc @n-boshnakov).

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
