### PR TITLE
Promote `testmachinery` tests to GA

### DIFF
--- a/.test-defs/TestSuiteRegistryCacheSerial.yaml
+++ b/.test-defs/TestSuiteRegistryCacheSerial.yaml
@@ -1,13 +1,13 @@
 apiVersion: testmachinery.sapcloud.io
 kind: TestDefinition
 metadata:
-  name: registry-cache-beta-serial-test-suite
+  name: registry-cache-serial-test-suite
 spec:
   owner: gardener-oq@listserv.sap.com
-  description: registry-cache extension test suite that includes all serial beta tests
+  description: registry-cache extension test suite that includes all serial tests
 
   activeDeadlineSeconds: 13200
-  labels: ["shoot", "beta"]
+  labels: ["shoot"]
   behavior:
   - serial
 
@@ -19,7 +19,7 @@ spec:
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE
       -shoot-name=$SHOOT_NAME
-      -ginkgo.focus="\[BETA\].*\[SERIAL\]"
+      -ginkgo.focus="\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
       -ginkgo.timeout=9000s
 

--- a/.test-defs/TestSuiteRegistryCacheSerial.yaml
+++ b/.test-defs/TestSuiteRegistryCacheSerial.yaml
@@ -7,7 +7,6 @@ spec:
   description: registry-cache extension test suite that includes all serial tests
 
   activeDeadlineSeconds: 13200
-  labels: ["shoot"]
   behavior:
   - serial
 

--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -26,7 +26,7 @@ const (
 var _ = Describe("Shoot registry cache testing", func() {
 	f := framework.NewShootFramework(nil)
 
-	f.Serial().Beta().CIt("should enable and disable the registry-cache extension", func(parentCtx context.Context) {
+	f.Serial().CIt("should enable and disable the registry-cache extension", func(parentCtx context.Context) {
 		By("Enable the registry-cache extension")
 		ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -28,7 +28,7 @@ const (
 var _ = Describe("Shoot registry cache testing", func() {
 	f := framework.NewShootFramework(nil)
 
-	f.Serial().Beta().CIt("should enable extension, hibernate Shoot, reconcile Shoot, wake up Shoot, disable extension", func(parentCtx context.Context) {
+	f.Serial().CIt("should enable extension, hibernate Shoot, reconcile Shoot, wake up Shoot, disable extension", func(parentCtx context.Context) {
 		By("Enable the registry-cache extension")
 		ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()

--- a/test/testmachinery/shoot/enable_rotate_ca_disable_test.go
+++ b/test/testmachinery/shoot/enable_rotate_ca_disable_test.go
@@ -29,7 +29,7 @@ const (
 var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 	f := framework.NewShootFramework(nil)
 
-	f.Serial().Beta().CIt("should enable extension, rotate CA, disable extension", func(parentCtx context.Context) {
+	f.Serial().CIt("should enable extension, rotate CA, disable extension", func(parentCtx context.Context) {
 		By("Enable the registry-cache extension")
 		ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/217 and https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/235.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The registry-cache extension test-machinery tests are no longer beta.
```
