### PR TITLE
Make decoding of `Raw` to configs consistent

### DIFF
--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -60,7 +60,7 @@ func (o *RegistryOptions) Complete() error {
 	}
 
 	config := configapi.Configuration{}
-	if err = runtime.DecodeInto(decoder, data, &config); err != nil {
+	if err := runtime.DecodeInto(decoder, data, &config); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -60,8 +60,7 @@ func (o *RegistryOptions) Complete() error {
 	}
 
 	config := configapi.Configuration{}
-	_, _, err = decoder.Decode(data, nil, &config)
-	if err != nil {
+	if err = runtime.DecodeInto(decoder, data, &config); err != nil {
 		return err
 	}
 

--- a/pkg/controller/cache/actuator.go
+++ b/pkg/controller/cache/actuator.go
@@ -69,7 +69,7 @@ func (a *actuator) Reconcile(ctx context.Context, logger logr.Logger, ex *extens
 	}
 
 	registryConfig := &api.RegistryConfig{}
-	if _, _, err := a.decoder.Decode(ex.Spec.ProviderConfig.Raw, nil, registryConfig); err != nil {
+	if err := runtime.DecodeInto(a.decoder, ex.Spec.ProviderConfig.Raw, registryConfig); err != nil {
 		return fmt.Errorf("failed to decode provider config: %w", err)
 	}
 

--- a/pkg/webhook/cache/ensurer.go
+++ b/pkg/webhook/cache/ensurer.go
@@ -166,7 +166,7 @@ func (e *ensurer) getProviderStatus(ctx context.Context, cluster *extensionscont
 	}
 
 	registryStatus := &api.RegistryStatus{}
-	if _, _, err := e.decoder.Decode(extension.Status.ProviderStatus.Raw, nil, registryStatus); err != nil {
+	if err := runtime.DecodeInto(e.decoder, extension.Status.ProviderStatus.Raw, registryStatus); err != nil {
 		return nil, fmt.Errorf("failed to decode providerStatus of extension '%s': %w", client.ObjectKeyFromObject(extension), err)
 	}
 	return registryStatus, nil

--- a/pkg/webhook/mirror/ensurer.go
+++ b/pkg/webhook/mirror/ensurer.go
@@ -64,7 +64,7 @@ func (e *ensurer) EnsureCRIConfig(ctx context.Context, gctx gcontext.GardenConte
 	}
 
 	mirrorConfig := &api.MirrorConfig{}
-	if _, _, err := e.decoder.Decode(extension.Spec.ProviderConfig.Raw, nil, mirrorConfig); err != nil {
+	if err := runtime.DecodeInto(e.decoder, extension.Spec.ProviderConfig.Raw, mirrorConfig); err != nil {
 		return fmt.Errorf("failed to decode providerConfig of extension '%s': %w", client.ObjectKeyFromObject(extension), err)
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/209

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
