### PR TITLE
Fix a corner case in the non-TLS to TLS registry-cache migration

### DIFF
--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -238,36 +238,6 @@ proxy:
 				return config
 			}
 
-			_ = func(name, upstream, remoteURL string) *corev1.Service {
-				return &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: "kube-system",
-						Labels: map[string]string{
-							"app":           name,
-							"upstream-host": upstream,
-						},
-						Annotations: map[string]string{
-							"upstream":   upstream,
-							"remote-url": remoteURL,
-						},
-					},
-					Spec: corev1.ServiceSpec{
-						Selector: map[string]string{
-							"app":           name,
-							"upstream-host": upstream,
-						},
-						Ports: []corev1.ServicePort{{
-							Name:       "registry-cache",
-							Port:       5000,
-							Protocol:   corev1.ProtocolTCP,
-							TargetPort: intstr.FromString("registry-cache"),
-						}},
-						Type: corev1.ServiceTypeClusterIP,
-					},
-				}
-			}
-
 			statefulSetFor = func(name, upstream, size, configSecretName, tlsSecretName, tlsSecretChecksum string, storageClassName *string, additionalEnvs []corev1.EnvVar) *appsv1.StatefulSet {
 				env := []corev1.EnvVar{
 					{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
We found that we have a race during the non-TLS to TLS migration.

In order to move the registry-cache Services from the `extension-registry-cache` MR to the `extension-registry-cache-services` MR, we patch the MR status to remove the Services from the `extension-registry-cache` MR status: https://github.com/gardener/gardener-extension-registry-cache/blob/f614b47ce02c1c21cb19316229113ae5bdaf6333/pkg/controller/cache/actuator.go#L76-L81

However, it might be the case that after this operation and before we update the desired resources in the e `extension-registry-cache` MR, the MR is reconciled by the GRM (syncPeriod=1min).

If this happens, removal of the Services from the `extension-registry-cache` MR is accepted as deletion of the Services and the Services are deleted later on.

```
2025-01-23T07:18:12.516Z {"log":{"ManagedResource":{"name":"extension-registry-cache","namespace":"shoot--foo--bar"},"controller":"managedresource","controllerGroup":"resources.gardener.cloud","controllerKind":"ManagedResource","level":"info","msg":"Deleting","name":"extension-registry-cache","namespace":"shoot--foo--bar","reconcileID":"7920531a-8bca-4042-98f1-e9b853151e46","resource":"v1/Service/kube-system/registry-europe-docker-pkg-dev","ts":"2025-01-23T07:18:12.516Z"}}
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A corner case causing the registry-cache Service to be deleted (and later on recreated again) during the non-TLS to TLS migration (from `registry-cache@v0.12` to `registry-cache@v.013`) is now mitigated.
```
