### PR TITLE
dependabot: Ignore go rc versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,11 +15,17 @@ updates:
   directory: /
   schedule:
     interval: daily
+  ignore:
+  - dependency-name: "golang"
+    versions: ["*rc*"]
   labels:
   - kind/enhancement
 - package-ecosystem: docker
   directory: /.test-defs
   schedule:
     interval: daily
+  ignore:
+  - dependency-name: "golang"
+    versions: ["*rc*"]
   labels:
   - kind/enhancement


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
We don't want dependabot PRs for golang release candidate (rc) versions. Examples:
- https://github.com/gardener/gardener-extension-registry-cache/pull/332
- https://github.com/gardener/gardener-extension-registry-cache/pull/333

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
