### PR TITLE
dependabot: Fix the ignore of go rc versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,7 +17,7 @@ updates:
     interval: daily
   ignore:
   - dependency-name: "golang"
-    versions: ["*rc*"]
+    versions: ["*.*rc*"]
   labels:
   - kind/enhancement
 - package-ecosystem: docker
@@ -26,6 +26,6 @@ updates:
     interval: daily
   ignore:
   - dependency-name: "golang"
-    versions: ["*rc*"]
+    versions: ["*.*rc*"]
   labels:
   - kind/enhancement


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
After https://github.com/gardener/gardener-extension-registry-cache/pull/334, our dependabot config is invalid with:
```
The property '#/updates/1/ignore/0/versions' includes invalid version requirements for a docker ignore condition
The property '#/updates/2/ignore/0/versions' includes invalid version requirements for a docker ignore condition
```

I copied the ignore approach from a wrong repo: https://github.com/gardener/ingress-default-backend

This PR reflects what VPA uses: https://github.com/kubernetes/autoscaler/blob/4bf8991122b8b2c669b43400a60e8dfbc36e1d36/.github/dependabot.yml

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-registry-cache/pull/334

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
