### PR TITLE
Add DNS service names in secret config

### DIFF
--- a/pkg/secrets/config.go
+++ b/pkg/secrets/config.go
@@ -10,9 +10,11 @@ import (
 	"time"
 
 	extensionssecretsmanager "github.com/gardener/gardener/extensions/pkg/util/secret/manager"
+	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener-extension-registry-cache/pkg/constants"
@@ -48,7 +50,8 @@ func ConfigsFor(services []corev1.Service) []extensionssecretsmanager.SecretConf
 				Name:                        name,
 				CommonName:                  name,
 				CertType:                    secretutils.ServerCert,
-				IPAddresses:                 []net.IP{net.ParseIP(service.Spec.ClusterIP).To4()},
+				DNSNames:                    kubernetesutils.DNSNamesForService(service.Name, metav1.NamespaceSystem),
+				IPAddresses:                 []net.IP{net.ParseIP(service.Spec.ClusterIP)},
 				Validity:                    ptr.To(90 * 24 * time.Hour),
 				SkipPublishingCACertificate: true,
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
The registry cache service DNS names are included in `Subject Alternative Name` of the server certificate. This will allow 
access to the registry cache using the service name (as in the `prow` use case).
The service's ClusterIP is no longer converted to IPv4 to support IPv6 as well. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The registry cache DNS service names are now included in the `Subject Alternative Name` of the server certificate.
```

```other operator
Registry cache Services with IPv6 `spec.clusterIP` are now supported.
```