### PR TITLE
Fix reconciliciation for a cache with a long upstream

### DIFF
--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"strings"
 	"text/template"
 	"time"
 
@@ -245,7 +244,7 @@ func (r *registryCaches) computeResourcesDataForRegistryCache(ctx context.Contex
 
 	var (
 		upstreamLabel = registryutils.ComputeUpstreamLabelValue(cache.Upstream)
-		name          = "registry-" + strings.ReplaceAll(upstreamLabel, ".", "-")
+		name          = registryutils.ComputeKubernetesResourceName(cache.Upstream)
 		remoteURL     = ptr.Deref(cache.RemoteURL, registryutils.GetUpstreamURL(cache.Upstream))
 		configValues  = map[string]interface{}{
 			"http_addr":       fmt.Sprintf(":%d", constants.RegistryCachePort),

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -522,7 +522,7 @@ source /entrypoint.sh /etc/distribution/config.yml
 				dockerConfigSecret := configSecretFor("registry-docker-io", "docker.io", configYAMLFor("https://registry-1.docker.io", "336h0m0s", "", "", true))
 				arConfigSecret := configSecretFor("registry-europe-docker-pkg-dev", "europe-docker.pkg.dev", configYAMLFor("https://europe-docker.pkg.dev", "0s", "", "", false))
 
-				dockerSecretsManagerSecret, ok := secretsManager.Get("docker.io-tls")
+				dockerSecretsManagerSecret, ok := secretsManager.Get("registry-docker-io-tls")
 				Expect(ok).To(BeTrue())
 				dockerTLSSecret := tlsSecretFor("registry-docker-io", "docker.io", dockerSecretsManagerSecret.Data["ca.crt"], dockerSecretsManagerSecret.Data["ca.key"])
 
@@ -551,7 +551,7 @@ source /entrypoint.sh /etc/distribution/config.yml
 				dockerConfigSecret := configSecretFor("registry-docker-io", "docker.io", configYAMLFor("https://registry-1.docker.io", "336h0m0s", "", "", true))
 				arConfigSecret := configSecretFor("registry-europe-docker-pkg-dev", "europe-docker.pkg.dev", configYAMLFor("https://europe-docker.pkg.dev", "0s", "", "", false))
 
-				dockerSecretsManagerSecret, ok := secretsManager.Get("docker.io-tls")
+				dockerSecretsManagerSecret, ok := secretsManager.Get("registry-docker-io-tls")
 				Expect(ok).To(BeTrue())
 				dockerTLSSecret := tlsSecretFor("registry-docker-io", "docker.io", dockerSecretsManagerSecret.Data["ca.crt"], dockerSecretsManagerSecret.Data["ca.key"])
 
@@ -596,7 +596,7 @@ source /entrypoint.sh /etc/distribution/config.yml
 				dockerConfigSecret := configSecretFor("registry-docker-io", "docker.io", configYAMLFor("https://registry-1.docker.io", "336h0m0s", "", "", true))
 				arConfigSecret := configSecretFor("registry-europe-docker-pkg-dev", "europe-docker.pkg.dev", configYAMLFor("https://europe-docker.pkg.dev", "0s", "", "", false))
 
-				dockerSecretsManagerSecret, ok := secretsManager.Get("docker.io-tls")
+				dockerSecretsManagerSecret, ok := secretsManager.Get("registry-docker-io-tls")
 				Expect(ok).To(BeTrue())
 				dockerTLSSecret := tlsSecretFor("registry-docker-io", "docker.io", dockerSecretsManagerSecret.Data["ca.crt"], dockerSecretsManagerSecret.Data["ca.key"])
 
@@ -701,7 +701,7 @@ source /entrypoint.sh /etc/distribution/config.yml
 				dockerConfigSecret := configSecretFor("registry-docker-io", "docker.io", configYAMLFor("https://registry-1.docker.io", "336h0m0s", "docker-user", "s3cret", true))
 				arConfigSecret := configSecretFor("registry-europe-docker-pkg-dev", "europe-docker.pkg.dev", configYAMLFor("https://europe-docker.pkg.dev", "0s", "ar-user", `{"foo":"bar"}`, false))
 
-				dockerSecretsManagerSecret, ok := secretsManager.Get("docker.io-tls")
+				dockerSecretsManagerSecret, ok := secretsManager.Get("registry-docker-io-tls")
 				Expect(ok).To(BeTrue())
 				dockerTLSSecret := tlsSecretFor("registry-docker-io", "docker.io", dockerSecretsManagerSecret.Data["ca.crt"], dockerSecretsManagerSecret.Data["ca.key"])
 

--- a/pkg/secrets/config.go
+++ b/pkg/secrets/config.go
@@ -6,7 +6,6 @@ package secrets
 
 import (
 	"net"
-	"strings"
 	"time"
 
 	extensionssecretsmanager "github.com/gardener/gardener/extensions/pkg/util/secret/manager"
@@ -18,6 +17,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener-extension-registry-cache/pkg/constants"
+	registryutils "github.com/gardener/gardener-extension-registry-cache/pkg/utils/registry"
 )
 
 const (
@@ -69,5 +69,6 @@ func ConfigsFor(services []corev1.Service) []extensionssecretsmanager.SecretConf
 
 // TLSSecretNameForUpstream returns a TLS Secret name for a given upstream.
 func TLSSecretNameForUpstream(upstream string) string {
-	return strings.ReplaceAll(upstream, ":", "-") + "-tls"
+	name := registryutils.ComputeKubernetesResourceName(upstream)
+	return name + "-tls"
 }

--- a/pkg/secrets/config_test.go
+++ b/pkg/secrets/config_test.go
@@ -5,10 +5,16 @@
 package secrets_test
 
 import (
+	"net"
 	"testing"
+	"time"
 
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gardener/gardener-extension-registry-cache/pkg/secrets"
 )
@@ -20,11 +26,103 @@ func TestSecrets(t *testing.T) {
 
 var _ = Describe("Secrets", func() {
 
-	DescribeTable("#TLSSecretNameForUpstream",
-		func(upstream, expected string) {
-			Expect(secrets.TLSSecretNameForUpstream(upstream)).To(Equal(expected))
-		},
-		Entry("upstream without port", "my-registry.io", "my-registry.io-tls"),
-		Entry("upstream ends with port", "my-registry.io:5000", "my-registry.io-5000-tls"),
-	)
+	Describe("#ConfigsFor", func() {
+		It("should return secret config for CA only when no services are passed", func() {
+			services := []corev1.Service{}
+
+			actual := secrets.ConfigsFor(services)
+			Expect(actual).To(HaveLen(1))
+			Expect(actual).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"Name":       Equal("ca-extension-registry-cache"),
+						"CommonName": Equal("ca-extension-registry-cache"),
+						"CertType":   Equal(secretutils.CACert),
+						"Validity":   PointTo(Equal(730 * 24 * time.Hour)),
+					})),
+				}),
+			))
+		})
+
+		It("should return secret configs for CA and TLS certificates", func() {
+			services := []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "registry-docker-io",
+						Annotations: map[string]string{
+							"upstream": "docker.io",
+							"scheme":   "https",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "10.4.0.10",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "registry-europe-docker-pkg-dev",
+						Annotations: map[string]string{
+							"upstream": "europe-docker.pkg.dev",
+							"scheme":   "http",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "10.4.0.11",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "registry-my-very-long-registry-very-long-subdo-2fae3",
+						Annotations: map[string]string{
+							"upstream": "my-very-long-registry.very-long-subdomain.io",
+							"scheme":   "https",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "10.4.0.12",
+					},
+				},
+			}
+
+			actual := secrets.ConfigsFor(services)
+			Expect(actual).To(HaveLen(3))
+			Expect(actual).To(ConsistOf(
+				MatchFields(IgnoreExtras, Fields{
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"Name":       Equal("ca-extension-registry-cache"),
+						"CommonName": Equal("ca-extension-registry-cache"),
+						"CertType":   Equal(secretutils.CACert),
+						"Validity":   PointTo(Equal(730 * 24 * time.Hour)),
+					})),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"Name":                        Equal("registry-docker-io-tls"),
+						"CommonName":                  Equal("registry-docker-io-tls"),
+						"CertType":                    Equal(secretutils.ServerCert),
+						"DNSNames":                    ConsistOf("registry-docker-io", "registry-docker-io.kube-system", "registry-docker-io.kube-system.svc", "registry-docker-io.kube-system.svc.cluster.local"),
+						"IPAddresses":                 ConsistOf([]net.IP{net.IPv4(10, 4, 0, 10)}),
+						"Validity":                    PointTo(Equal(90 * 24 * time.Hour)),
+						"SkipPublishingCACertificate": BeTrue(),
+					})),
+				}),
+				MatchFields(IgnoreExtras, Fields{
+					"Config": PointTo(MatchFields(IgnoreExtras, Fields{
+						"Name":       Equal("registry-my-very-long-registry-very-long-subdo-2fae3-tls"),
+						"CommonName": Equal("registry-my-very-long-registry-very-long-subdo-2fae3-tls"),
+						"CertType":   Equal(secretutils.ServerCert),
+						"DNSNames": ConsistOf(
+							"registry-my-very-long-registry-very-long-subdo-2fae3",
+							"registry-my-very-long-registry-very-long-subdo-2fae3.kube-system",
+							"registry-my-very-long-registry-very-long-subdo-2fae3.kube-system.svc",
+							"registry-my-very-long-registry-very-long-subdo-2fae3.kube-system.svc.cluster.local",
+						),
+						"IPAddresses":                 ConsistOf([]net.IP{net.IPv4(10, 4, 0, 12)}),
+						"Validity":                    PointTo(Equal(90 * 24 * time.Hour)),
+						"SkipPublishingCACertificate": BeTrue(),
+					})),
+				}),
+			))
+		})
+	})
 })

--- a/pkg/utils/registry/registry.go
+++ b/pkg/utils/registry/registry.go
@@ -55,3 +55,13 @@ func ComputeUpstreamLabelValue(upstream string) string {
 	}
 	return upstreamLabel
 }
+
+// ComputeKubernetesResourceName computes a name for a Kubernetes resource (StatefulSet, Secret, ...) by given upstream.
+// The returned name is conformed with the restriction that a StatefulSet name can be at most 52 chars.
+// For more details, see https://github.com/kubernetes/kubernetes/issues/64023.
+//
+// The returned name is at most 52 chars.
+func ComputeKubernetesResourceName(upstream string) string {
+	upstreamLabel := ComputeUpstreamLabelValue(upstream)
+	return "registry-" + strings.ReplaceAll(upstreamLabel, ".", "-")
+}

--- a/pkg/utils/registry/registry_test.go
+++ b/pkg/utils/registry/registry_test.go
@@ -43,4 +43,16 @@ var _ = Describe("Registry utils", func() {
 		Entry("long upstream ends with port", "my-very-long-registry.long-subdomain.io:8443", "my-very-long-registry.long-subdomain.-8cb9e"),
 		Entry("long upstream ends like a port", "my-very-long-registry.long-subdomain.io-8443", "my-very-long-registry.long-subdomain.-e91ed"),
 	)
+
+	DescribeTable("#ComputeKubernetesResourceName",
+		func(upstream, expected string) {
+			Expect(registryutils.ComputeKubernetesResourceName(upstream)).To(Equal(expected))
+		},
+		Entry("short upstream", "my-registry.io", "registry-my-registry-io"),
+		Entry("short upstream ends with port", "my-registry.io:5000", "registry-my-registry-io-5000"),
+		Entry("short upstream ends like a port", "my-registry.io-5000", "registry-my-registry-io-5000"),
+		Entry("long upstream", "my-very-long-registry.very-long-subdomain.io", "registry-my-very-long-registry-very-long-subdo-2fae3"),
+		Entry("long upstream ends with port", "my-very-long-registry.long-subdomain.io:8443", "registry-my-very-long-registry-long-subdomain--8cb9e"),
+		Entry("long upstream ends like a port", "my-very-long-registry.long-subdomain.io-8443", "registry-my-very-long-registry-long-subdomain--e91ed"),
+	)
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
See https://github.com/gardener/gardener-extension-registry-cache/issues/337.

This PR uses the same name (suffixed with `-tls`) which is used for the StatefulSet and the other resources. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-registry-cache/issues/337

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing reconciliation to fail for caches with long upstreams (> 59 chars) is now fixed.
```
