### PR TITLE
Fix a race condition that could occur while switching between TLS enabled and disabled

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,4 @@
 !go.sum
 !Makefile
 !VERSION
+!third_party

--- a/pkg/component/registrycacheservices/registry_cache_services.go
+++ b/pkg/component/registrycacheservices/registry_cache_services.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/helper"
 	"github.com/gardener/gardener-extension-registry-cache/pkg/constants"
 	registryutils "github.com/gardener/gardener-extension-registry-cache/pkg/utils/registry"
+	forkedmanagedresources "github.com/gardener/gardener-extension-registry-cache/third_party/gardener/gardener/pkg/utils/managedresources"
 )
 
 const (
@@ -42,11 +43,13 @@ type Values struct {
 // New creates a new instance of component.DeployWaiter for registry cache services.
 func New(
 	client client.Client,
+	apiReader client.Reader,
 	namespace string,
 	values Values,
 ) component.DeployWaiter {
 	return &registryCacheServices{
 		client:    client,
+		apiReader: apiReader,
 		namespace: namespace,
 		values:    values,
 	}
@@ -54,6 +57,7 @@ func New(
 
 type registryCacheServices struct {
 	client    client.Client
+	apiReader client.Reader
 	namespace string
 	values    Values
 }
@@ -89,7 +93,8 @@ func (r *registryCacheServices) Wait(ctx context.Context) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForManagedResource)
 	defer cancel()
 
-	return managedresources.WaitUntilHealthy(timeoutCtx, r.client, r.namespace, managedResourceName)
+	// TODO(ialidzhikov): Switch back to managedresources.WaitUntilHealthy when we vendor gardener/gardener version that contains https://github.com/gardener/gardener/pull/11321.
+	return forkedmanagedresources.WaitUntilHealthy(timeoutCtx, r.apiReader, r.namespace, managedResourceName)
 }
 
 func (r *registryCacheServices) WaitCleanup(ctx context.Context) error {

--- a/pkg/component/registrycacheservices/registry_cache_services_test.go
+++ b/pkg/component/registrycacheservices/registry_cache_services_test.go
@@ -121,7 +121,7 @@ var _ = Describe("RegistryCacheServices", func() {
 	})
 
 	JustBeforeEach(func() {
-		registryCacheServices = New(c, namespace, values)
+		registryCacheServices = New(c, c, namespace, values)
 	})
 
 	Describe("#Deploy", func() {

--- a/pkg/controller/cache/add.go
+++ b/pkg/controller/cache/add.go
@@ -50,7 +50,7 @@ func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddO
 	decoder := serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder()
 
 	return extension.Add(ctx, mgr, extension.AddArgs{
-		Actuator:          NewActuator(mgr.GetClient(), decoder, opts.Config),
+		Actuator:          NewActuator(mgr.GetClient(), mgr.GetAPIReader(), decoder, opts.Config),
 		ControllerOptions: opts.ControllerOptions,
 		Name:              ControllerName,
 		FinalizerSuffix:   FinalizerSuffix,

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -48,6 +48,7 @@ build:
             - pkg/utils/registry
             - pkg/webhook/cache
             - pkg/webhook/mirror
+            - third_party/gardener/gardener/pkg/utils/managedresources
             - VERSION
         ldflags:
           - '{{.LD_FLAGS}}'

--- a/third_party/gardener/gardener/pkg/utils/managedresources/managedresources.go
+++ b/third_party/gardener/gardener/pkg/utils/managedresources/managedresources.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package managedresources
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// IntervalWait is the interval when waiting for managed resources.
+var IntervalWait = 2 * time.Second
+
+// WaitUntilHealthy waits until the given managed resource is healthy.
+func WaitUntilHealthy(ctx context.Context, client client.Reader, namespace, name string) error {
+	return waitUntilHealthy(ctx, client, namespace, name, false)
+}
+
+func waitUntilHealthy(ctx context.Context, c client.Reader, namespace, name string, andNotProgressing bool) error {
+	obj := &resourcesv1alpha1.ManagedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	return retry.Until(ctx, IntervalWait, func(ctx context.Context) (done bool, err error) {
+		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj); err != nil {
+			return retry.SevereError(err)
+		}
+
+		if err := health.CheckManagedResource(obj); err != nil {
+			return retry.MinorError(fmt.Errorf("managed resource %s/%s is not healthy", namespace, name))
+		}
+
+		if andNotProgressing {
+			if err := health.CheckManagedResourceProgressing(obj); err != nil {
+				return retry.MinorError(fmt.Errorf("managed resource %s/%s is still progressing", namespace, name))
+			}
+		}
+
+		return retry.Ok()
+	})
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
In https://github.com/gardener/gardener-extension-registry-cache/blob/d37f25b4940de579955fd1b3e42503f2ee524182/pkg/controller/cache/actuator.go#L89-L95 the following race happens: The `Wait` call succeeds right away because it acts on outdated ManagedResource version. A cached client is being used and it is not yet updated the local cache with the later revision of the ManagedResource that contains the updates after the `Deploy` func.

With this PR, we aim to address this race by using a direct client which will always read the ManagedResource from the kube-apiserver.
Hence, we should not act on outdated revision of the ManagedResource resource.

**Which issue(s) this PR fixes**:
Fixes #343 
Follow-up after https://github.com/gardener/gardener-extension-registry-cache/pull/331

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
