### PR TITLE
Revert "dependabot: Ignore go rc versions"

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -15,17 +15,11 @@ updates:
   directory: /
   schedule:
     interval: daily
-  ignore:
-  - dependency-name: "golang"
-    versions: ["*.*rc*"]
   labels:
   - kind/enhancement
 - package-ecosystem: docker
   directory: /.test-defs
   schedule:
     interval: daily
-  ignore:
-  - dependency-name: "golang"
-    versions: ["*.*rc*"]
   labels:
   - kind/enhancement


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
This reverts commit ecc66b7528aa3cc88fe4dd505b8b517b6b88842c.

Even after the try to fix it in https://github.com/gardener/gardener-extension-registry-cache/pull/335, https://github.com/gardener/gardener-extension-registry-cache/network/updates still fails with:
```
The property '#/updates/1/ignore/0/versions' includes invalid version requirements for a docker ignore condition
The property '#/updates/2/ignore/0/versions' includes invalid version requirements for a docker ignore condition
```

While dependabot still somehow continues to work despite this error (see created PRs https://github.com/gardener/gardener-extension-registry-cache/pull/341 and https://github.com/gardener/gardener-extension-registry-cache/pull/342), we would like to preserve the functionality to trigger new version checks from https://github.com/gardener/gardener-extension-registry-cache/network/updates.

For the golang `rc` versions, we can ignore the corresponding version in the corresponding PR and close the PR.
Later on, dependabot should consider the newly released patch versions and raise PRs for them.

**Which issue(s) this PR fixes**:
Reverts https://github.com/gardener/gardener-extension-registry-cache/pull/334

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
