### PR TITLE
e2e tests: Disable VPA for the e2e test Shoots

### DIFF
--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -33,8 +33,6 @@ func DefaultShootCreationFramework() *framework.ShootCreationFramework {
 
 // DefaultShoot returns a Shoot object with default values for the e2e tests.
 func DefaultShoot(generateName string) *gardencorev1beta1.Shoot {
-	purpose := gardencorev1beta1.ShootPurposeTesting
-
 	return &gardencorev1beta1.Shoot{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: generateName,
@@ -43,10 +41,12 @@ func DefaultShoot(generateName string) *gardencorev1beta1.Shoot {
 			},
 		},
 		Spec: gardencorev1beta1.ShootSpec{
-			CloudProfile:      &gardencorev1beta1.CloudProfileReference{Name: "local"},
+			CloudProfile: &gardencorev1beta1.CloudProfileReference{
+				Name: "local",
+			},
 			SecretBindingName: ptr.To("local"),
 			Region:            "local",
-			Purpose:           &purpose,
+			Purpose:           ptr.To(gardencorev1beta1.ShootPurposeTesting),
 			Kubernetes: gardencorev1beta1.Kubernetes{
 				Version: "1.31.1",
 				Kubelet: &gardencorev1beta1.KubeletConfig{
@@ -54,7 +54,9 @@ func DefaultShoot(generateName string) *gardencorev1beta1.Shoot {
 					RegistryPullQPS:     ptr.To[int32](10),
 					RegistryBurst:       ptr.To[int32](20),
 				},
-				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
+				VerticalPodAutoscaler: &gardencorev1beta1.VerticalPodAutoscaler{
+					Enabled: false,
+				},
 			},
 			Networking: &gardencorev1beta1.Networking{
 				Type:  ptr.To("calico"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
We now and then see flakes in the e2e tests. See #283.

I was not able yet to reproduce the flakes from #283 but as we talked offline, disabling the VPA for the e2e test Shoots makes sense.

In a local run of the test, VPA eviction happen few seconds after the test Pod was created (and its image was pulled by the registry cache).

Event:
```yaml
- apiVersion: v1
  count: 1
  eventTime: null
  firstTimestamp: "2025-02-12T15:52:48Z"
  involvedObject:
    apiVersion: v1
    kind: Pod
    name: registry-ghcr-io-0
    namespace: kube-system
    resourceVersion: "1883"
    uid: 27f85490-5cfc-4e28-8e92-c22c5b916b2e
  kind: Event
  lastTimestamp: "2025-02-12T15:52:48Z"
  message: Pod was evicted by VPA Updater to apply resource recommendation.
  metadata:
    creationTimestamp: "2025-02-12T15:52:48Z"
    name: registry-ghcr-io-0.182380dd41cc5858
    namespace: kube-system
    resourceVersion: "282"
    uid: 0bd2c7d0-4ba6-4562-b369-76d48ae07941
  reason: EvictedByVPA
  reportingComponent: vpa-updater
  reportingInstance: ""
  source:
    component: vpa-updater
  type: Normal
```

Test run:
```
STEP: [ghcr.io] Verify registry-cache works @ 02/12/25 17:52:36.411
STEP: Create jitesoft-alpine Pod @ 02/12/25 17:52:36.411
STEP: Wait until jitesoft-alpine Pod is running @ 02/12/25 17:52:36.43
{"level":"info","ts":"2025-02-12T17:52:36.435+0200","logger":"test","msg":"Waiting for Pod to be ready","pod":{"name":"jitesoft-alpine-fs52f","namespace":"default"}}
{"level":"info","ts":"2025-02-12T17:52:41.440+0200","logger":"test","msg":"Pod is ready now","pod":{"name":"jitesoft-alpine-fs52f","namespace":"default"}}
{"level":"info","ts":"2025-02-12T17:52:41.445+0200","logger":"test","msg":"Node architecture","name":"machine-shoot--local--e2e-cache-def-local-bdfcf-dmd6j","arch":"arm64"}
STEP: Verify the registry cache pulled the ghcr.io/jitesoft/alpine:3.18.8 image @ 02/12/25 17:52:41.445
```

You can see that the test Pod is created at `17:52:36` and was running at `17:52:41` while VPA eviction for the registry cache happened at `17:52:48`.

When the registry Pod is evicted and it is unavailable for a short period of time, containerd could fall back to the upstream.

**Which issue(s) this PR fixes**:
Potential mitigation for https://github.com/gardener/gardener-extension-registry-cache/issues/283

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
