### PR TITLE
Annotate registry cache StatefulSet with the `reference.resources.gardener.cloud/secret-<hash>` annotation 

### DIFF
--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -235,7 +235,6 @@ func (r *registryCaches) computeResourcesDataForRegistryCache(ctx context.Contex
 	}
 
 	const (
-		checksumAnnotation       = "checksum/secret-%s-tls"
 		registryCacheVolumeName  = "cache-volume"
 		registryConfigVolumeName = "config-volume"
 		registryCertsVolumeName  = "certs-volume"

--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -19,6 +19,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/component"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/utils"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
@@ -476,10 +477,6 @@ source /entrypoint.sh /etc/distribution/config.yml
 		}
 		utilruntime.Must(kubernetesutils.MakeUnique(tlsSecret))
 
-		statefulSet.Spec.Template.Annotations = map[string]string{
-			fmt.Sprintf(checksumAnnotation, name): utils.ComputeChecksum(tlsSecret.Data),
-		}
-
 		statefulSet.Spec.Template.Spec.Volumes = append(statefulSet.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: registryCertsVolumeName,
 			VolumeSource: corev1.VolumeSource{
@@ -494,6 +491,8 @@ source /entrypoint.sh /etc/distribution/config.yml
 			MountPath: "/etc/distribution/certs",
 		})
 	}
+
+	utilruntime.Must(references.InjectAnnotations(statefulSet))
 
 	var vpa *vpaautoscalingv1.VerticalPodAutoscaler
 	if r.values.VPAEnabled {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:

The registry cache StatefulSet is annotated with `reference.resources.gardener.cloud/secret-<hash>` annotation for config and TLS secrets. This will prevent garbage collection of secrets that are still in use.

The custom checksum annotation is removed from the StatefulSet's Pod template as it is no longer needed.

**Which issue(s) this PR fixes**:
Fixes #362 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue where the referenced registry-cache config or TLS Secret is being garbage collected while it is still in-use has been fixed.
```
