### PR TITLE
Fix reuse compliance

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -23,12 +23,9 @@ Files:
   go.sum
   hack/api-reference/*.json
   local-setup
-  pkg/component/registrycaches/alerting-rules/registry-cache.rules.yaml
   pkg/component/registrycaches/monitoring/dashboard.json
   pkg/component/registrycaches/templates/config.yml.tpl
-  pkg/webhook/cache/scripts/configure-containerd-registries.sh
-  pkg/webhook/mirror/templates/hosts.toml.tpl
-  **/testdata/**
+  skaffold-operator.yaml
   skaffold.yaml
 Copyright: 2024 SAP SE or an SAP affiliate company and Gardener contributors
 License: Apache-2.0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
```
The following files have no copyright and licensing information:
* skaffold-operator.yaml
```

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-registry-cache/pull/361

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
