### PR TITLE
skaffold: Clean up no longer needed custom `tagPolicy`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,6 @@ ci-e2e-kind:
 export SKAFFOLD_BUILD_CONCURRENCY = 0
 extension-up extension-dev extension-operator-up: export SKAFFOLD_DEFAULT_REPO = garden.local.gardener.cloud:5001
 extension-up extension-dev extension-operator-up: export SKAFFOLD_PUSH = true
-extension-up extension-dev remote-extension-up extension-operator-up: export EXTENSION_VERSION = $(VERSION)
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
 extension-up extension-dev extension-down extension-operator-up extension-operator-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=extension-local
 

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -91,15 +91,6 @@ build:
           alias: IMG
   insecureRegistries:
     - garden.local.gardener.cloud:5001
-  tagPolicy:
-    customTemplate:
-      template: '{{.version}}-{{.sha}}'
-      components:
-        - name: version
-          envTemplate:
-            template: '{{.EXTENSION_VERSION}}'
-        - name: sha
-          inputDigest: {}
 manifests:
   rawYaml:
     - local-setup/operator-extension-resource.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -40,17 +40,6 @@ build:
         main: ./cmd/gardener-extension-registry-cache
   insecureRegistries:
     - garden.local.gardener.cloud:5001
-  tagPolicy:
-    customTemplate:
-      template: '{{.version}}-{{.sha}}'
-      components:
-        - name: version
-          envTemplate:
-            template: '{{.EXTENSION_VERSION}}'
-        # inputDigest is used to inject a digest of the artifact source into the built image tag
-        # and therefore into the SKAFFOLD_IMAGE environment variable which is used when generating the corresponding ControllerDeployment
-        - name: sha
-          inputDigest: {}
 manifests:
   kustomize:
     paths:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
See https://github.com/gardener/gardener-extension-shoot-rsyslog-relp/pull/242#pullrequestreview-2660854875

With https://github.com/gardener/gardener-extension-registry-cache/issues/278, we introduced a custom `tagPolicy`.

After https://github.com/gardener/gardener-extension-registry-cache/pull/357, we no longer need it as we no longer make use of the `SKAFFOLD_IMAGE` env var.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-registry-cache/pull/357

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
