### PR TITLE
Disable VPA for the TM tests

### DIFF
--- a/test/common/common.go
+++ b/test/common/common.go
@@ -138,6 +138,11 @@ func RemoveExtension(shoot *gardencorev1beta1.Shoot, extensionType string) {
 	})
 }
 
+// IsVerticalPodAutoscalerEnabled returns true if the VPA is enabled
+func IsVerticalPodAutoscalerEnabled(shoot *gardencorev1beta1.Shoot) bool {
+	return shoot.Spec.Kubernetes.VerticalPodAutoscaler != nil && shoot.Spec.Kubernetes.VerticalPodAutoscaler.Enabled
+}
+
 // VerifyHostsTOMLFilesCreatedForAllNodes verifies that hosts.toml files for the given upstreams are created for all Nodes
 // with the given hosts.toml file content.
 func VerifyHostsTOMLFilesCreatedForAllNodes(ctx context.Context, log logr.Logger, shootClient kubernetes.Interface, upstreamToHostsTOML map[string]string) {

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -28,6 +28,8 @@ const (
 var _ = Describe("Shoot registry cache testing", func() {
 	f := framework.NewShootFramework(nil)
 
+	var isVerticalPodAutoscalerDisabled bool
+
 	f.Serial().CIt("should enable extension, hibernate Shoot, reconcile Shoot, wake up Shoot, disable extension", func(parentCtx context.Context) {
 		By("Enable the registry-cache extension")
 		ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
@@ -42,6 +44,10 @@ var _ = Describe("Shoot registry cache testing", func() {
 			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha3.RegistryCache{
 				{Upstream: "ghcr.io", Volume: &v1alpha3.Volume{Size: &size}},
 			})
+			if common.IsVerticalPodAutoscalerEnabled(shoot) {
+				shoot.Spec.Kubernetes.VerticalPodAutoscaler.Enabled = false
+				isVerticalPodAutoscalerDisabled = true
+			}
 
 			return nil
 		})).To(Succeed())
@@ -84,6 +90,9 @@ var _ = Describe("Shoot registry cache testing", func() {
 			By("Disable the registry-cache extension")
 			Expect(f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
 				common.RemoveExtension(shoot, "registry-cache")
+				if isVerticalPodAutoscalerDisabled {
+					shoot.Spec.Kubernetes.VerticalPodAutoscaler.Enabled = true
+				}
 
 				return nil
 			})).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Disable the VPA for the test machinery tests. The flaky test issue reported in #283 is observing in TM tests logs.
Similar to #351 

**Which issue(s) this PR fixes**:
Fixes #283 for the TM tests

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
