### PR TITLE
Use a helper func for getting a valid volume size in TM tests

### DIFF
--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gardener/gardener/test/framework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
@@ -36,12 +35,7 @@ var _ = Describe("Shoot registry cache testing", func() {
 		ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()
 		Expect(f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
-			size := resource.MustParse("2Gi")
-			if shoot.Spec.Provider.Type == "alicloud" {
-				// On AliCloud the minimum size for SSD volumes is 20Gi.
-				size = resource.MustParse("20Gi")
-			}
-
+			size := GetValidVolumeSize(shoot.Spec.Provider.Type, "2Gi")
 			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha3.RegistryCache{
 				{Upstream: "ghcr.io", Volume: &v1alpha3.Volume{Size: &size}},
 			})

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gardener/gardener/test/framework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
@@ -37,12 +36,7 @@ var _ = Describe("Shoot registry cache testing", func() {
 		ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()
 		Expect(f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
-			size := resource.MustParse("2Gi")
-			if shoot.Spec.Provider.Type == "alicloud" {
-				// On AliCloud the minimum size for SSD volumes is 20Gi.
-				size = resource.MustParse("20Gi")
-			}
-
+			size := GetValidVolumeSize(shoot.Spec.Provider.Type, "2Gi")
 			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha3.RegistryCache{
 				{Upstream: "ghcr.io", Volume: &v1alpha3.Volume{Size: &size}},
 			})

--- a/test/testmachinery/shoot/enable_rotate_ca_disable_test.go
+++ b/test/testmachinery/shoot/enable_rotate_ca_disable_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gardener/gardener/test/utils/access"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
@@ -38,12 +37,7 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 		ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()
 		Expect(f.UpdateShoot(ctx, func(shoot *gardencorev1beta1.Shoot) error {
-			size := resource.MustParse("2Gi")
-			if shoot.Spec.Provider.Type == "alicloud" {
-				// On AliCloud the minimum size for SSD volumes is 20Gi.
-				size = resource.MustParse("20Gi")
-			}
-
+			size := GetValidVolumeSize(shoot.Spec.Provider.Type, "2Gi")
 			common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha3.RegistryCache{
 				{Upstream: "ghcr.io", Volume: &v1alpha3.Volume{Size: &size}},
 			})

--- a/test/testmachinery/shoot/shoot_suite_test.go
+++ b/test/testmachinery/shoot/shoot_suite_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gardener/gardener/test/framework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func init() {
@@ -19,4 +20,18 @@ func init() {
 func TestShoot(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Shoot Suite")
+}
+
+// GetValidVolumeSize returns a valid volume size for the given cloud provider.
+// If the given size is smaller than the minimum volume size permitted by cloud provider on which the cluster is running, it will return the minimum size.
+func GetValidVolumeSize(provider string, size string) resource.Quantity {
+	sizeAsQuantity := resource.MustParse(size)
+	minSizeAlicloud := resource.MustParse("20Gi")
+
+	if provider == "alicloud" && sizeAsQuantity.Cmp(minSizeAlicloud) < 0 {
+		// On AliCloud the minimum size for SSD volumes is 20Gi.
+		return minSizeAlicloud
+	}
+
+	return sizeAsQuantity
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:
We have the following checks duplicated many times:
- https://github.com/gardener/gardener-extension-registry-cache/blob/04d64024c62f0c5d41b1952ce6c9adf803d3fb8b/test/testmachinery/shoot/enable_disable_test.go#L34-L38
- https://github.com/gardener/gardener-extension-registry-cache/blob/04d64024c62f0c5d41b1952ce6c9adf803d3fb8b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go#L36-L40
- https://github.com/gardener/gardener-extension-registry-cache/blob/04d64024c62f0c5d41b1952ce6c9adf803d3fb8b/test/testmachinery/shoot/enable_rotate_ca_disable_test.go#L37-L41

This PR extracts the duplication into a helper func.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
