### PR TITLE
Remove maxAllowed from the registry cache VPA

### DIFF
--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -522,10 +522,6 @@ source /entrypoint.sh /etc/distribution/config.yml
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceMemory: resource.MustParse("20Mi"),
 							},
-							MaxAllowed: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("4"),
-								corev1.ResourceMemory: resource.MustParse("8Gi"),
-							},
 						},
 					},
 				},

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -455,10 +455,6 @@ source /entrypoint.sh /etc/distribution/config.yml
 									MinAllowed: corev1.ResourceList{
 										corev1.ResourceMemory: resource.MustParse("20Mi"),
 									},
-									MaxAllowed: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("4"),
-										corev1.ResourceMemory: resource.MustParse("8Gi"),
-									},
 								},
 							},
 						},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This PR removes maxAllowed from the registry cache VPA.

We see occurrences where the registry has to consume more than 8Gi (filesystem page caches). We saw memory usage of 12Gi dropped to 1Gi after the kernel OOM killer was invoked which also cleared all the page cache memory. 

I was not able to reproduce such behaviour in a test environment in the same scale - registry cache having a high and constant memory usage due to active page cache. 

Previously, maxAllowed was used in Gardener components to prevent vpa-recommender issuing recommendations that make the Pod unschedulable (see https://github.com/kubernetes/autoscaler/issues/7147). However, in VPA 1.4.0 it will be possible to configure vpa-recommender via flags on what is the max amount of cpu/memory it can recommend. VPA maxAllowed values take precedence over the global vpa-recommender flags.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
registry cache's VPA no longer specifies maxAllowed. Previously, this led to cases where the VPA maxAllowed did not allow the vpa-recommender to apply higher resource recommendations.
```
