### PR TITLE
Add PodDistruptionBudget when HA is enabled

### DIFF
--- a/pkg/apis/registry/helper/helper.go
+++ b/pkg/apis/registry/helper/helper.go
@@ -64,3 +64,8 @@ func TLSEnabled(cache *registry.RegistryCache) bool {
 
 	return cache.HTTP.TLS
 }
+
+// HighAvailabilityEnabled returns whether high availability for the registry cache is enabled.
+func HighAvailabilityEnabled(cache *registry.RegistryCache) bool {
+	return cache.HighAvailability != nil && cache.HighAvailability.Enabled
+}

--- a/pkg/apis/registry/helper/helper_test.go
+++ b/pkg/apis/registry/helper/helper_test.go
@@ -114,4 +114,13 @@ var _ = Describe("Helpers", func() {
 		Entry("http.tls is false", &registry.RegistryCache{HTTP: &registry.HTTP{TLS: false}}, false),
 		Entry("http.tls is true", &registry.RegistryCache{HTTP: &registry.HTTP{TLS: true}}, true),
 	)
+
+	DescribeTable("#HighAvailabilityEnabled",
+		func(cache *registry.RegistryCache, expected bool) {
+			Expect(helper.HighAvailabilityEnabled(cache)).To(Equal(expected))
+		},
+		Entry("highAvailability is nil", &registry.RegistryCache{HighAvailability: nil}, false),
+		Entry("highAvailability.enabled is false", &registry.RegistryCache{HighAvailability: &registry.HighAvailability{Enabled: false}}, false),
+		Entry("highAvailability.enabled is true", &registry.RegistryCache{HighAvailability: &registry.HighAvailability{Enabled: true}}, true),
+	)
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
According to [High Availability docs](https://github.com/gardener/gardener/blob/v1.118.0/docs/development/high-availability-of-components.md#convenient-application-of-these-rules):
> 2. All components should be generally equipped with `PodDisruptionBudget`s with `.spec.maxUnavailable=1` and `unhealthyPodEvictionPolicy=AlwaysAllow`

This especially makes sense when running a registry cache with HA enabled (2 replicas):
- A PodDistruptionBudget will prevent eviction of the registry-cache Pod if the other replica is unhealthy.
- During rolling updates of the registry cache StatefulSet, it will prevent both of the registry cache replicas to be unhealthy at the same time.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-registry-cache/pull/298.

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
