### PR TITLE
tm tests: Add expectation framework's Shoot client not to be nil

### DIFF
--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -31,6 +31,8 @@ var _ = Describe("Shoot registry cache testing", func() {
 	)
 
 	f.Serial().CIt("should enable and disable the registry-cache extension", func(parentCtx context.Context) {
+		Expect(f.ShootClient).NotTo(BeNil(), "Shoot client should not be nil. If it is the Shoot might be hibernated")
+
 		By("Enable the registry-cache extension")
 		ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -60,8 +60,8 @@ var _ = Describe("Shoot registry cache testing", func() {
 		By("Hibernate Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
 		defer cancel()
-		Expect(f.HibernateShoot(ctx)).To(Succeed())
 		isShootHibernated = true
+		Expect(f.HibernateShoot(ctx)).To(Succeed())
 
 		By("Reconcile Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 5*time.Minute)

--- a/test/testmachinery/shoot/enable_rotate_ca_disable_test.go
+++ b/test/testmachinery/shoot/enable_rotate_ca_disable_test.go
@@ -33,6 +33,8 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 	)
 
 	f.Serial().CIt("should enable extension, rotate CA, disable extension", func(parentCtx context.Context) {
+		Expect(f.ShootClient).NotTo(BeNil(), "Shoot client should not be nil. If it is the Shoot might be hibernated")
+
 		By("Enable the registry-cache extension")
 		ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
We see and in some cases, previous executions of TM tests leave the TM Shoot in hibernated state.
When our TM tests are executed against such hibernated Shoot, they fail with:
```
• [PANICKED] [122.661 seconds]
Shoot registry cache testing  [It] [SERIAL] [SHOOT] should enable and disable the registry-cache extension
/go/pkg/mod/github.com/gardener/gardener@v1.115.1/test/framework/gingko_utils.go:16

  [PANICKED] Test Panicked
  In [It] at: /usr/local/go/src/runtime/panic.go:262 @ 05/08/25 01:15:14.268

  runtime error: invalid memory address or nil pointer dereference

  Full Stack Trace
    github.com/gardener/gardener-extension-registry-cache/test/common.VerifyRegistryCache({0x2b7f8b8, 0xc000371110}, {{0x2b85778?, 0xc00132e3c0?}, 0x2b7f8b8?}, {0x0, 0x0}, {0x28080f4, 0x1e}, {0xc000b7fef8, ...})
    	/src/test/common/common.go:230 +0x338
    github.com/gardener/gardener-extension-registry-cache/test/testmachinery/shoot_test.init.func1.1({0x2b7f8b8, 0xc000371110})
    	/src/test/testmachinery/shoot/enable_disable_test.go:52 +0x1c9
    github.com/gardener/gardener/test/framework.CIt.contextify.func1()
    	/go/pkg/mod/github.com/gardener/gardener@v1.115.1/test/framework/gingko_utils.go:54 +0x4f
```

The `f.ShootClient` is nil because of the logic in https://github.com/gardener/gardener/blob/38fb61d2216c063b3b70894b3da1b9ecf578167d/test/framework/shootframework.go#L176-L178. The `f.ShootClient` won't be initialized when the Shoot `.spec.hibernation.enabled=true`.

This PR makes the test fail in a better way with a proper message instead of a nil pointer panic when we receive such a hibernated Shoot from the test machinery.

With this PR, we will no longer wake up unconditionally the shoot in the AfterEach of the hibernation TM test. Previously, our AfterEach block was waking up the hibernated which was passed by the test machinery. We will now wake it up only if we hibernated it as part of the test execution.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
We don't need such a check for e2e test as there we always create a new Shoot as part of the test.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
