### PR TITLE
Allow configuring registry cache service name

### DIFF
--- a/docs/usage/registry-cache/configuration.md
+++ b/docs/usage/registry-cache/configuration.md
@@ -60,6 +60,7 @@ spec:
         secretReferenceName: quay-credentials
       - upstream: my-registry.io:5000
         remoteURL: http://my-registry.io:5000
+        serviceNameSuffix: static-name
   # ...
   resources:
   - name: quay-credentials
@@ -92,6 +93,8 @@ This field is immutable. If the field is not specified, then the [default Storag
 The `providerConfig.caches[].garbageCollection.ttl` field is the time to live of a blob in the cache. If the field is set to `0s`, the garbage collection is disabled. Defaults to `168h` (7 days). See the [Garbage Collection section](#garbage-collection) for more details.
 
 The `providerConfig.caches[].secretReferenceName` is the name of the reference for the Secret containing the upstream registry credentials. To cache images from a private registry, credentials to the upstream registry should be supplied. For more details, see [How to provide credentials for upstream registry](upstream-credentials.md#how-to-provide-credentials-for-upstream-registry).
+
+The `providerConfig.caches[].serviceNameSuffix` field allows to customize the naming of the deployed service after the `registry-` prefix. This is useful in scenarios where environment specific registries should be available under the same name across shoots.
 
 > [!NOTE]
 > It is only possible to provide one set of credentials for one private upstream registry.

--- a/hack/api-reference/registry.md
+++ b/hack/api-reference/registry.md
@@ -276,6 +276,19 @@ HighAvailability
 <p>HighAvailability contains settings for high availability of the registry cache.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>serviceNameSuffix</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceNameSuffix allows to customize the naming of the deployed service.
+If not specified, the service suffix will be generated from the upstream.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="registry.extensions.gardener.cloud/v1alpha3.RegistryCacheStatus">RegistryCacheStatus

--- a/pkg/apis/registry/types.go
+++ b/pkg/apis/registry/types.go
@@ -44,6 +44,10 @@ type RegistryCache struct {
 	HTTP *HTTP
 	//HighAvailability contains settings for high availability of the registry cache.
 	HighAvailability *HighAvailability
+	// ServiceNameSuffix allows to customize the naming of the deployed service.
+	// If not specified, the service suffix will be generated from the upstream.
+	// +optional
+	ServiceNameSuffix *string
 }
 
 // Volume contains settings for the registry cache volume.

--- a/pkg/apis/registry/types.go
+++ b/pkg/apis/registry/types.go
@@ -46,7 +46,6 @@ type RegistryCache struct {
 	HighAvailability *HighAvailability
 	// ServiceNameSuffix allows to customize the naming of the deployed service.
 	// If not specified, the service suffix will be generated from the upstream.
-	// +optional
 	ServiceNameSuffix *string
 }
 

--- a/pkg/apis/registry/v1alpha3/types.go
+++ b/pkg/apis/registry/v1alpha3/types.go
@@ -52,6 +52,10 @@ type RegistryCache struct {
 	// HighAvailability contains settings for high availability of the registry cache.
 	// +optional
 	HighAvailability *HighAvailability `json:"highAvailability,omitempty"`
+	// ServiceNameSuffix allows to customize the naming of the deployed service.
+	// If not specified, the service suffix will be generated from the upstream.
+	// +optional
+	ServiceNameSuffix *string `json:"serviceNameSuffix,omitempty"`
 }
 
 // Volume contains settings for the registry cache volume.

--- a/pkg/apis/registry/v1alpha3/zz_generated.conversion.go
+++ b/pkg/apis/registry/v1alpha3/zz_generated.conversion.go
@@ -208,6 +208,7 @@ func autoConvert_v1alpha3_RegistryCache_To_registry_RegistryCache(in *RegistryCa
 	out.Proxy = (*registry.Proxy)(unsafe.Pointer(in.Proxy))
 	out.HTTP = (*registry.HTTP)(unsafe.Pointer(in.HTTP))
 	out.HighAvailability = (*registry.HighAvailability)(unsafe.Pointer(in.HighAvailability))
+	out.ServiceNameSuffix = (*string)(unsafe.Pointer(in.ServiceNameSuffix))
 	return nil
 }
 
@@ -225,6 +226,7 @@ func autoConvert_registry_RegistryCache_To_v1alpha3_RegistryCache(in *registry.R
 	out.Proxy = (*Proxy)(unsafe.Pointer(in.Proxy))
 	out.HTTP = (*HTTP)(unsafe.Pointer(in.HTTP))
 	out.HighAvailability = (*HighAvailability)(unsafe.Pointer(in.HighAvailability))
+	out.ServiceNameSuffix = (*string)(unsafe.Pointer(in.ServiceNameSuffix))
 	return nil
 }
 

--- a/pkg/apis/registry/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/registry/v1alpha3/zz_generated.deepcopy.go
@@ -125,6 +125,11 @@ func (in *RegistryCache) DeepCopyInto(out *RegistryCache) {
 		*out = new(HighAvailability)
 		**out = **in
 	}
+	if in.ServiceNameSuffix != nil {
+		in, out := &in.ServiceNameSuffix, &out.ServiceNameSuffix
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/registry/validation/validation.go
+++ b/pkg/apis/registry/validation/validation.go
@@ -128,10 +128,10 @@ func ValidateUpstream(fldPath *field.Path, upstream string) field.ErrorList {
 }
 
 // A label value length and a resource name length limits are 63 chars.
-// The cache resources name have prefix 'registry-', thus the label value length is limited to 43.
-const serviceNameSuffixValueLimit = 43
+// The cache resources name have prefix 'registry-', thus the label value length is limited to 54.
+const serviceNameSuffixValueLimit = 54
 
-// ValidateServiceNameSuffix validates that serviceNameSuffix is valid DNS subdomain (RFC 1123) and not longer than 43 characters.
+// ValidateServiceNameSuffix validates that serviceNameSuffix is valid DNS subdomain (RFC 1123) and not longer than 54 characters.
 func ValidateServiceNameSuffix(fldPath *field.Path, serviceNameSuffix string) field.ErrorList {
 	var allErrs field.ErrorList
 	for _, msg := range validation.IsDNS1123Label(serviceNameSuffix) {

--- a/pkg/apis/registry/validation/validation.go
+++ b/pkg/apis/registry/validation/validation.go
@@ -42,11 +42,18 @@ func ValidateRegistryConfig(config *registry.RegistryConfig, fldPath *field.Path
 		} else {
 			upstreams.Insert(cache.Upstream)
 		}
+	}
+
+	for i, cache := range config.Caches {
 		if cache.ServiceNameSuffix != nil {
 			if serviceNameSuffixes.Has(*cache.ServiceNameSuffix) {
 				allErrs = append(allErrs, field.Duplicate(fldPath.Child("caches").Index(i).Child("serviceNameSuffix"), *cache.ServiceNameSuffix))
 			} else {
 				serviceNameSuffixes.Insert(*cache.ServiceNameSuffix)
+			}
+
+			if cache.Upstream != *cache.ServiceNameSuffix && upstreams.Has(*cache.ServiceNameSuffix) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("caches").Index(i).Child("serviceNameSuffix"), *cache.ServiceNameSuffix, "cannot collide with upstream"))
 			}
 		}
 	}

--- a/pkg/apis/registry/validation/validation_test.go
+++ b/pkg/apis/registry/validation/validation_test.go
@@ -254,10 +254,10 @@ var _ = Describe("Validation", func() {
 					"Detail":   Equal("must not contain dots"),
 				})),
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"BadValue": Equal(strings.Repeat("n", 55)),
+					"Type":     Equal(field.ErrorTypeTooLong),
+					"BadValue": Equal("<value omitted>"),
 					"Field":    Equal("providerConfig.caches[1].serviceNameSuffix"),
-					"Detail":   Equal("cannot be longer than 54 characters"),
+					"Detail":   Equal("may not be more than 54 bytes"),
 				})),
 			))
 		})
@@ -450,6 +450,20 @@ var _ = Describe("Validation", func() {
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("providerConfig.caches[0].garbageCollection.ttl"),
 					"Detail": Equal("garbage collection cannot be enabled (ttl > 0) once it is disabled (ttl = 0)"),
+				})),
+			))
+		})
+
+		It("should deny cache service name suffix update", func() {
+			oldRegistryConfig.Caches[0].ServiceNameSuffix = ptr.To("static-name1")
+			registryConfig.Caches[0].ServiceNameSuffix = ptr.To("static-name2")
+
+			Expect(ValidateRegistryConfigUpdate(oldRegistryConfig, registryConfig, fldPath)).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal("providerConfig.caches[0].serviceNameSuffix"),
+					"BadValue": Equal(ptr.To("static-name2")),
+					"Detail":   Equal("field is immutable"),
 				})),
 			))
 		})

--- a/pkg/apis/registry/zz_generated.deepcopy.go
+++ b/pkg/apis/registry/zz_generated.deepcopy.go
@@ -125,6 +125,11 @@ func (in *RegistryCache) DeepCopyInto(out *RegistryCache) {
 		*out = new(HighAvailability)
 		**out = **in
 	}
+	if in.ServiceNameSuffix != nil {
+		in, out := &in.ServiceNameSuffix, &out.ServiceNameSuffix
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -277,6 +277,7 @@ func (r *registryCaches) registryCacheObjects(ctx context.Context, cache *regist
 	var (
 		upstreamLabel = registryutils.ComputeUpstreamLabelValue(cache.Upstream)
 		name          = registryutils.ComputeKubernetesResourceName(cache.Upstream)
+		serviceName   = registryutils.ComputeServiceName(cache.Upstream, cache.ServiceNameSuffix)
 		remoteURL     = ptr.Deref(cache.RemoteURL, registryutils.GetUpstreamURL(cache.Upstream))
 		configValues  = map[string]interface{}{
 			"http_addr":       fmt.Sprintf(":%d", constants.RegistryCacheServerPort),
@@ -336,7 +337,7 @@ func (r *registryCaches) registryCacheObjects(ctx context.Context, cache *regist
 			Labels:    registryutils.GetLabels(name, upstreamLabel),
 		},
 		Spec: appsv1.StatefulSetSpec{
-			ServiceName: name,
+			ServiceName: serviceName,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: registryutils.GetLabels(name, upstreamLabel),
 			},

--- a/pkg/component/registrycacheservices/registry_cache_services_test.go
+++ b/pkg/component/registrycacheservices/registry_cache_services_test.go
@@ -57,13 +57,13 @@ var _ = Describe("RegistryCacheServices", func() {
 
 		registryCacheServices component.DeployWaiter
 
-		serviceFor = func(name, upstream, remoteURL, scheme string) *corev1.Service {
+		serviceFor = func(name, appLabelValue, upstream, remoteURL, scheme string) *corev1.Service {
 			return &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: "kube-system",
 					Labels: map[string]string{
-						"app":           name,
+						"app":           appLabelValue,
 						"upstream-host": upstream,
 					},
 					Annotations: map[string]string{
@@ -74,7 +74,7 @@ var _ = Describe("RegistryCacheServices", func() {
 				},
 				Spec: corev1.ServiceSpec{
 					Selector: map[string]string{
-						"app":           name,
+						"app":           appLabelValue,
 						"upstream-host": upstream,
 					},
 					Ports: []corev1.ServicePort{
@@ -109,6 +109,7 @@ var _ = Describe("RegistryCacheServices", func() {
 					HTTP: &registryapi.HTTP{
 						TLS: false,
 					},
+					ServiceNameSuffix: ptr.To("static-name"),
 				},
 			},
 		}
@@ -156,8 +157,8 @@ var _ = Describe("RegistryCacheServices", func() {
 			Expect(managedResource).To(DeepEqual(expectedMr))
 
 			Expect(managedResource).To(consistOf(
-				serviceFor("registry-docker-io", "docker.io", "https://registry-1.docker.io", "https"),
-				serviceFor("registry-europe-docker-pkg-dev", "europe-docker.pkg.dev", "https://europe-docker.pkg.dev", "http"),
+				serviceFor("registry-docker-io", "registry-docker-io", "docker.io", "https://registry-1.docker.io", "https"),
+				serviceFor("registry-static-name", "registry-europe-docker-pkg-dev", "europe-docker.pkg.dev", "https://europe-docker.pkg.dev", "http"),
 			))
 		})
 	})

--- a/pkg/utils/registry/registry.go
+++ b/pkg/utils/registry/registry.go
@@ -56,6 +56,8 @@ func ComputeUpstreamLabelValue(upstream string) string {
 	return upstreamLabel
 }
 
+const namePrefix = "registry-"
+
 // ComputeKubernetesResourceName computes a name for a Kubernetes resource (StatefulSet, Secret, ...) by given upstream.
 // The returned name is conformed with the restriction that a StatefulSet name can be at most 52 chars.
 // For more details, see https://github.com/kubernetes/kubernetes/issues/64023.
@@ -63,5 +65,14 @@ func ComputeUpstreamLabelValue(upstream string) string {
 // The returned name is at most 52 chars.
 func ComputeKubernetesResourceName(upstream string) string {
 	upstreamLabel := ComputeUpstreamLabelValue(upstream)
-	return "registry-" + strings.ReplaceAll(upstreamLabel, ".", "-")
+	return namePrefix + strings.ReplaceAll(upstreamLabel, ".", "-")
+}
+
+// ComputeServiceName computes a name for a Kubernetes Service by given upstream and optional suffix.
+func ComputeServiceName(upstream string, serviceNameSuffix *string) string {
+	if serviceNameSuffix != nil {
+		return namePrefix + *serviceNameSuffix
+	}
+
+	return ComputeKubernetesResourceName(upstream)
 }

--- a/pkg/utils/registry/registry_test.go
+++ b/pkg/utils/registry/registry_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
 
 	registryutils "github.com/gardener/gardener-extension-registry-cache/pkg/utils/registry"
 )
@@ -54,5 +55,13 @@ var _ = Describe("Registry utils", func() {
 		Entry("long upstream", "my-very-long-registry.very-long-subdomain.io", "registry-my-very-long-registry-very-long-subdo-2fae3"),
 		Entry("long upstream ends with port", "my-very-long-registry.long-subdomain.io:8443", "registry-my-very-long-registry-long-subdomain--8cb9e"),
 		Entry("long upstream ends like a port", "my-very-long-registry.long-subdomain.io-8443", "registry-my-very-long-registry-long-subdomain--e91ed"),
+	)
+
+	DescribeTable("#ComputeServiceName",
+		func(upsteam string, serviceNameSuffix *string, expected string) {
+			Expect(registryutils.ComputeServiceName(upsteam, serviceNameSuffix)).To(Equal(expected))
+		},
+		Entry("service name suffix is nil", "my-registry.io", nil, "registry-my-registry-io"),
+		Entry("service name suffix is set", "my-registry.io", ptr.To("static-name"), "registry-static-name"),
 	)
 })

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -58,6 +58,7 @@ build:
             - pkg/apis/registry/v1alpha3
             - pkg/apis/registry/validation
             - pkg/constants
+            - pkg/utils/registry
             - VERSION
         ldflags:
           - '{{.LD_FLAGS}}'

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -88,6 +88,7 @@ build:
             - pkg/apis/registry/v1alpha3
             - pkg/apis/registry/validation
             - pkg/constants
+            - pkg/utils/registry
             - VERSION
         ldflags:
           - '{{.LD_FLAGS}}'

--- a/test/e2e/cache/create_enabled_force_delete.go
+++ b/test/e2e/cache/create_enabled_force_delete.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
 	"github.com/gardener/gardener-extension-registry-cache/test/common"
@@ -24,7 +25,11 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 	shoot := e2e.DefaultShoot("e2e-cache-fd")
 	size := resource.MustParse("2Gi")
 	common.AddOrUpdateRegistryCacheExtension(shoot, []v1alpha3.RegistryCache{
-		{Upstream: "gardener-extension-registry-cache-tests.common.repositories.cloud.sap", Volume: &v1alpha3.Volume{Size: &size}},
+		{
+			Upstream:          "gardener-extension-registry-cache-tests.common.repositories.cloud.sap",
+			Volume:            &v1alpha3.Volume{Size: &size},
+			ServiceNameSuffix: ptr.To("gardener-extension-registry-cache-tests"),
+		},
 	})
 	f.Shoot = shoot
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
This PR adds a new configuration option: "serviceNameSuffix".
This option allows to customize the service name after the `registry-` part.
I chose to only allow customization of the suffix as we prob. don't want to allow users specifying the service name as something like "kube-dns".
See mentioned issue for potential use-cases.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-registry-cache/issues/402

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The registry-cache service name can now be customized with the `serviceNameSuffix` option.
```
