### PR TITLE
Support for Kubernetes v1.33

### DIFF
--- a/pkg/component/registrycacheservices/registry_cache_services.go
+++ b/pkg/component/registrycacheservices/registry_cache_services.go
@@ -137,12 +137,20 @@ func computeResourcesDataForService(cache *registryapi.RegistryCache) *corev1.Se
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: registryutils.GetLabels(name, upstreamLabel),
-			Ports: []corev1.ServicePort{{
-				Name:       "registry-cache",
-				Port:       constants.RegistryCachePort,
-				Protocol:   corev1.ProtocolTCP,
-				TargetPort: intstr.FromString("registry-cache"),
-			}},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "registry-cache",
+					Port:       constants.RegistryCacheServerPort,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromString("registry-cache"),
+				},
+				{
+					Name:       "debug",
+					Port:       constants.RegistryCacheDebugPort,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromString("debug"),
+				},
+			},
 			Type: corev1.ServiceTypeClusterIP,
 		},
 	}

--- a/pkg/component/registrycacheservices/registry_cache_services_test.go
+++ b/pkg/component/registrycacheservices/registry_cache_services_test.go
@@ -77,12 +77,20 @@ var _ = Describe("RegistryCacheServices", func() {
 						"app":           name,
 						"upstream-host": upstream,
 					},
-					Ports: []corev1.ServicePort{{
-						Name:       "registry-cache",
-						Port:       5000,
-						Protocol:   corev1.ProtocolTCP,
-						TargetPort: intstr.FromString("registry-cache"),
-					}},
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "registry-cache",
+							Port:       5000,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromString("registry-cache"),
+						},
+						{
+							Name:       "debug",
+							Port:       5001,
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromString("debug"),
+						},
+					},
 					Type: corev1.ServiceTypeClusterIP,
 				},
 			}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -14,8 +14,10 @@ const (
 
 	// UpstreamHostLabel is a label on registry cache resources (Service, StatefulSet) which denotes the upstream host.
 	UpstreamHostLabel = "upstream-host"
-	// RegistryCachePort is the port on which the pull through cache serves requests.
-	RegistryCachePort = 5000
+	// RegistryCacheServerPort is the port on which the pull through cache server is served.
+	RegistryCacheServerPort int32 = 5000
+	// RegistryCacheDebugPort is the port on which the debug server (used for metrics and health endpoints) is served.
+	RegistryCacheDebugPort int32 = 5001
 
 	// RemoteURLAnnotation is an annotation on registry cache Service which denotes the upstream registry URL.
 	RemoteURLAnnotation = "remote-url"

--- a/pkg/controller/cache/actuator.go
+++ b/pkg/controller/cache/actuator.go
@@ -237,7 +237,7 @@ func computeProviderStatus(services []corev1.Service, caSecretName *string) *v1a
 	for _, service := range services {
 		caches = append(caches, v1alpha3.RegistryCacheStatus{
 			Upstream:  service.Annotations[constants.UpstreamAnnotation],
-			Endpoint:  fmt.Sprintf("%s://%s:%d", service.Annotations[constants.SchemeAnnotation], service.Spec.ClusterIP, constants.RegistryCachePort),
+			Endpoint:  fmt.Sprintf("%s://%s:%d", service.Annotations[constants.SchemeAnnotation], service.Spec.ClusterIP, constants.RegistryCacheServerPort),
 			RemoteURL: service.Annotations[constants.RemoteURLAnnotation],
 		})
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source usability
/kind enhancement

**What this PR does / why we need it**:
This PR adds support for Kubernetes 1.33 to the extension.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11933
Fixes #432 

**Special notes for your reviewer**:
Starting with Kubernetes 1.33, a `deny-all` NetworkPolicy is deployed in the Shoot cluster. From [Upgrading to Kubernetes `v1.33`](https://github.com/gardener/gardener/blob/v1.125.0/docs/usage/shoot/shoot_kubernetes_versions.md#upgrading-to-kubernetes-v133):
> - A new `deny-all` `NetworkPolicy` is deployed into the `kube-system` namespace of the `Shoot` cluster. `Shoot` owners that run workloads in the `kube-system` namespace are required to explicitly allow their expected `Ingress` and `Egress` traffic in `kube-system` via `NetworkPolicies`.

According to our testing with @dimitar-kostadinov , the traffic from the GNA to the registry Pod was allowed when the registry Pod was on the same Node as the GNA. However, when the GNA is on another Node, the traffic is not allowed.
That's why we haven't notice the issue on local setup and e2e tests where we run minimum=maximum=1.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The registry-cache extension does now support shoot clusters with Kubernetes version 1.33.
```
