### PR TITLE
Bump golang from 1.24.6 to 1.24.7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
           # tests are run using prow for non-release-runs, so early-exit
           echo "dummy" > gosec-report.sarif
         fi
-      go-version: '1.24.6'
+      go-version: '1.24.7'
 
   oci-images:
     name: Build OCI-Images

--- a/.test-defs/TestSuiteRegistryCacheSerial.yaml
+++ b/.test-defs/TestSuiteRegistryCacheSerial.yaml
@@ -22,4 +22,4 @@ spec:
       -ginkgo.skip="\[DISRUPTIVE\]"
       -ginkgo.timeout=9000s
 
-  image: golang:1.24.6
+  image: golang:1.24.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.24.6 AS builder
+FROM golang:1.24.7 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-registry-cache
 

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ generate: $(VGOPATH) $(CONTROLLER_GEN) $(EXTENSION_GEN) $(GEN_CRD_API_REFERENCE_
 
 .PHONE: generate-in-docker
 generate-in-docker:
-	docker run --rm -it -v $(PWD):/go/src/github.com/gardener/gardener-extension-registry-cache golang:1.24.6 \
+	docker run --rm -it -v $(PWD):/go/src/github.com/gardener/gardener-extension-registry-cache golang:1.24.7 \
 		sh -c "cd /go/src/github.com/gardener/gardener-extension-registry-cache \
 				&& make tidy generate \
 				&& chown -R $(shell id -u):$(shell id -g) ."


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Bump golang from 1.24.6 to 1.24.7.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
I am raising a manual PR as there is already dependabot PR for golang 1.25.0 and dependabot won't raise a PR for 1.24.7.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
