### PR TITLE
Remove `spec.serviceName` and add `spec.revisionHistoryLimit=2` fields in the registry `StatefulSet`

### DIFF
--- a/pkg/apis/registry/validation/validation.go
+++ b/pkg/apis/registry/validation/validation.go
@@ -89,8 +89,6 @@ func ValidateRegistryConfigUpdate(oldConfig, newConfig *registry.RegistryConfig,
 			if !helper.GarbageCollectionEnabled(&oldCache) && helper.GarbageCollectionEnabled(&newCache) {
 				allErrs = append(allErrs, field.Invalid(cacheFldPath.Child("garbageCollection").Child("ttl"), newCache.GarbageCollection, "garbage collection cannot be enabled (ttl > 0) once it is disabled (ttl = 0)"))
 			}
-
-			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newCache.ServiceNameSuffix, oldCache.ServiceNameSuffix, cacheFldPath.Child("serviceNameSuffix"))...)
 		}
 	}
 

--- a/pkg/apis/registry/validation/validation_test.go
+++ b/pkg/apis/registry/validation/validation_test.go
@@ -453,20 +453,6 @@ var _ = Describe("Validation", func() {
 				})),
 			))
 		})
-
-		It("should deny cache service name suffix update", func() {
-			oldRegistryConfig.Caches[0].ServiceNameSuffix = ptr.To("static-name1")
-			registryConfig.Caches[0].ServiceNameSuffix = ptr.To("static-name2")
-
-			Expect(ValidateRegistryConfigUpdate(oldRegistryConfig, registryConfig, fldPath)).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("providerConfig.caches[0].serviceNameSuffix"),
-					"BadValue": Equal(ptr.To("static-name2")),
-					"Detail":   Equal("field is immutable"),
-				})),
-			))
-		})
 	})
 
 	Describe("#ValidateUpstreamRegistrySecret", func() {

--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -335,7 +335,7 @@ func (r *registryCaches) registryCacheObjects(ctx context.Context, cache *regist
 			Namespace: metav1.NamespaceSystem,
 			Labels:    registryutils.GetLabels(name, upstreamLabel),
 			// StatefulSets need to be recreated due to the removal of the `spec.serviceName` field and the addition of the `spec.revisionHistoryLimit` field.
-			// TODO(dimitar-kostadinov): Remove the `DeleteOnInvalidUpdate` annotation in the v0.19.0 release.
+			// TODO(dimitar-kostadinov): Remove the `DeleteOnInvalidUpdate` annotation in the v0.21.0 release.
 			Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
 		},
 		Spec: appsv1.StatefulSetSpec{

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -296,7 +296,7 @@ proxy:
 							"app":           name,
 							"upstream-host": upstream,
 						},
-						// TODO(dimitar-kostadinov): Remove the `DeleteOnInvalidUpdate` annotation in the v0.19.0 release.
+						// TODO(dimitar-kostadinov): Remove the `DeleteOnInvalidUpdate` annotation in the v0.21.0 release.
 						Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
 					},
 					Spec: appsv1.StatefulSetSpec{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
Removes the `spec.serviceName` form the registry `StatefulSet` as the `$(podname).$(governing service domain)` DNS records are not used and do not need to be managed by the controller.
The `revisionHistoryLimit=2` field is added to registry `StatefulSet` spec - ref #378.

**Which issue(s) this PR fixes**:
Fixes #378

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Registry cache Pods are no longer reachable using Pod DNS - `$(podname).$(governing service domain)`, for example `registry-docker-io-0.registry-docker-io.kube-system.svc.cluster.local`.
```

```other operator
The `spec.serviceName` field has been removed from the registry cache StatefulSet. All registry cache StatefulSets will be recreated once due to this change.
```
