### PR TITLE
change admission deployment name to be in line with all other known admission extensions

### DIFF
--- a/charts/admission/charts/application/templates/_helpers.tpl
+++ b/charts/admission/charts/application/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "name" -}}
-gardener-extension-registry-cache-admission
+gardener-extension-admission-registry-cache
 {{- end -}}
 
 {{- define "labels.app.key" -}}

--- a/charts/admission/charts/runtime/templates/_helpers.tpl
+++ b/charts/admission/charts/runtime/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "name" -}}
-gardener-extension-registry-cache-admission
+gardener-extension-admission-registry-cache
 {{- end -}}
 
 {{- define "labels.app.key" -}}


### PR DESCRIPTION
**How to categorize this PR?**
/area open-source

**What this PR does / why we need it**:
In order to integrate this extension with yake it should follow the same naming as all other admission extensions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
change the admission deployment name for consistency with other admission extensions
```
