### PR TITLE
Add default `.ocm/branch-info.yaml` file

### DIFF
--- a/.ocm/branch-info.yaml
+++ b/.ocm/branch-info.yaml
@@ -1,0 +1,5 @@
+release-branch-template: release-v$major.$minor # e.g. release-v1.0
+branch-policy:
+  significant-part: minor # major, minor, patch
+  supported-versions-count: 1
+  release-cadence: null # d (days), w (weeks), y | yr (years)


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduces the `.ocm/branch-info.yaml` file which is used to collect release-data compatible to the format used by the [endoflife.date](https://endoflife.date) project. Therefore, the `supported-versions-count` as well as `release-cadence` attributes are used to create an estimated end-of-life date (`(estimated) EoL Date = Release Date + supported-versions-count * release-cadence`). If there are irregular deviations from this rule, the release information may always be updated manually in the (internal) repository holding the release-data. The `significant-part` is the version part which is subject of being maintained. In case of questions, please reach out to CICD team.

**Special notes for your reviewer**:
The `.ocm/branch-info.yaml` file this PR introduces only contains the default values. This means, having no explicit branch info file is equivalent to having this file with the default values. Please adjust this PR/the file to reflect the release information which is actually valid for this component.

**How to categorize this PR?**

/area delivery
/kind task

**Which issue(s) this PR fixes**:
NONE

**Release note**:
```other developer
NONE
```