### PR TITLE
Add provision relevant mirror

### DIFF
--- a/docs/usage/registry-mirror/configuration.md
+++ b/docs/usage/registry-mirror/configuration.md
@@ -62,3 +62,7 @@ The value must include a scheme - `http://` or `https://`.
 
 The `providerConfig.mirror[].hosts[].capabilities` field represents the operations a host is capable of performing. This also represents the set of operations for which the mirror host may be trusted to perform. Defaults to `["pull"]`. The supported values are `pull` and `resolve`.
 See the [capabilities field documentation](https://github.com/containerd/containerd/blob/v1.7.0/docs/hosts.md#capabilities-field) for more information on which operations are considered trusted ones against public/private mirrors.
+
+The `providerConfig.mirror[].hosts[].caBundle` field sets an optional CABundle for the mirror.
+
+The `providerConfig.mirror[].provisionRelevant` field represents if the mirror is needed for provisioning a node (for example contains the `gardener-node-agent`). If this is set to true the mirror will be additionally added with the provision `operatingsystemconfig` to have the mirror available before the `gardener-node-agent` is running. After startup the `gardener-node-agent` will adopt the mirror and reconcile the mirror as usual.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.0
+	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.89.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -517,6 +517,8 @@ github.com/operator-framework/operator-lib v0.19.0 h1:az6ogYj21rtU0SF9uYctRLyKp2
 github.com/operator-framework/operator-lib v0.19.0/go.mod h1:KxycAjFnHt0DBtHmH3Jm7yHcY5sdrshPKTqM/HKAQ08=
 github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=
 github.com/ovh/go-ovh v1.9.0/go.mod h1:cTVDnl94z4tl8pP1uZ/8jlVxntjSIf09bNcQ5TJSC7c=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/perses/common v0.27.1-0.20250326140707-96e439b14e0e h1:AormqtWdtHdoQyGO90U1fRoElR0XQHmP0W9oJUsCOZY=
 github.com/perses/common v0.27.1-0.20250326140707-96e439b14e0e/go.mod h1:CMTbKu0uWCFKgo4oDVoT8GcMC0bKyDH4cNG3GVfi+rA=
 github.com/perses/perses v0.51.0 h1:lLssvsMjxFg2oP+vKX6pz2SFTfrUyso/A2/A/6oFens=

--- a/hack/api-reference/mirror.md
+++ b/hack/api-reference/mirror.md
@@ -80,6 +80,18 @@ The value must be a valid DNS subdomain (RFC 1123) and optionally a port.</p>
 <p>Hosts are the mirror hosts to be used for the upstream.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>provisionRelevant</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>ProvisionRelevant deploys the mirror config via the provision OSC. This is only needed if the gardener-node-agent
+is consumed via the mirror. Use this only if it is really needed.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="mirror.extensions.gardener.cloud/v1alpha1.MirrorHost">MirrorHost
@@ -125,6 +137,18 @@ string
 This also represents the set of operations for which the mirror host may be trusted to perform.
 The supported values are &ldquo;pull&rdquo; and &ldquo;resolve&rdquo;.
 Defaults to [&ldquo;pull&rdquo;].</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>caBundle</code></br>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CABundle is the CABundle for a MirrorHost.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/mirror/types.go
+++ b/pkg/apis/mirror/types.go
@@ -25,6 +25,9 @@ type MirrorConfiguration struct {
 	Upstream string
 	// Hosts are the mirror hosts to be used for the upstream.
 	Hosts []MirrorHost
+	// ProvisionRelevant deploys the mirror config via the provision OSC. This is only needed if the gardener-node-agent
+	// is consumed via the mirror.
+	ProvisionRelevant bool
 }
 
 // MirrorHost represents a mirror host.
@@ -35,6 +38,8 @@ type MirrorHost struct {
 	// This also represents the set of operations for which the mirror host may be trusted to perform.
 	// The supported values are "pull" and "resolve".
 	Capabilities []MirrorHostCapability
+	// CABundle is the CABundle for a MirrorHost.
+	CABundle []byte
 }
 
 // MirrorHostCapability represents a mirror host capability.

--- a/pkg/apis/mirror/v1alpha1/types.go
+++ b/pkg/apis/mirror/v1alpha1/types.go
@@ -25,6 +25,9 @@ type MirrorConfiguration struct {
 	Upstream string `json:"upstream"`
 	// Hosts are the mirror hosts to be used for the upstream.
 	Hosts []MirrorHost `json:"hosts"`
+	// ProvisionRelevant deploys the mirror config via the provision OSC. This is only needed if the gardener-node-agent
+	// is consumed via the mirror. Use this only if it is really needed.
+	ProvisionRelevant bool `json:"provisionRelevant"`
 }
 
 // MirrorHost represents a mirror host.
@@ -37,6 +40,9 @@ type MirrorHost struct {
 	// Defaults to ["pull"].
 	// +optional
 	Capabilities []MirrorHostCapability `json:"capabilities"`
+	// CABundle is the CABundle for a MirrorHost.
+	// +optional
+	CABundle []byte `json:"caBundle"`
 }
 
 // MirrorHostCapability represents a mirror host capability.

--- a/pkg/apis/mirror/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/mirror/v1alpha1/zz_generated.conversion.go
@@ -80,6 +80,7 @@ func Convert_mirror_MirrorConfig_To_v1alpha1_MirrorConfig(in *mirror.MirrorConfi
 func autoConvert_v1alpha1_MirrorConfiguration_To_mirror_MirrorConfiguration(in *MirrorConfiguration, out *mirror.MirrorConfiguration, s conversion.Scope) error {
 	out.Upstream = in.Upstream
 	out.Hosts = *(*[]mirror.MirrorHost)(unsafe.Pointer(&in.Hosts))
+	out.ProvisionRelevant = in.ProvisionRelevant
 	return nil
 }
 
@@ -91,6 +92,7 @@ func Convert_v1alpha1_MirrorConfiguration_To_mirror_MirrorConfiguration(in *Mirr
 func autoConvert_mirror_MirrorConfiguration_To_v1alpha1_MirrorConfiguration(in *mirror.MirrorConfiguration, out *MirrorConfiguration, s conversion.Scope) error {
 	out.Upstream = in.Upstream
 	out.Hosts = *(*[]MirrorHost)(unsafe.Pointer(&in.Hosts))
+	out.ProvisionRelevant = in.ProvisionRelevant
 	return nil
 }
 
@@ -102,6 +104,7 @@ func Convert_mirror_MirrorConfiguration_To_v1alpha1_MirrorConfiguration(in *mirr
 func autoConvert_v1alpha1_MirrorHost_To_mirror_MirrorHost(in *MirrorHost, out *mirror.MirrorHost, s conversion.Scope) error {
 	out.Host = in.Host
 	out.Capabilities = *(*[]mirror.MirrorHostCapability)(unsafe.Pointer(&in.Capabilities))
+	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
 	return nil
 }
 
@@ -113,6 +116,7 @@ func Convert_v1alpha1_MirrorHost_To_mirror_MirrorHost(in *MirrorHost, out *mirro
 func autoConvert_mirror_MirrorHost_To_v1alpha1_MirrorHost(in *mirror.MirrorHost, out *MirrorHost, s conversion.Scope) error {
 	out.Host = in.Host
 	out.Capabilities = *(*[]MirrorHostCapability)(unsafe.Pointer(&in.Capabilities))
+	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
 	return nil
 }
 

--- a/pkg/apis/mirror/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/mirror/v1alpha1/zz_generated.deepcopy.go
@@ -76,6 +76,11 @@ func (in *MirrorHost) DeepCopyInto(out *MirrorHost) {
 		*out = make([]MirrorHostCapability, len(*in))
 		copy(*out, *in)
 	}
+	if in.CABundle != nil {
+		in, out := &in.CABundle, &out.CABundle
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/mirror/zz_generated.deepcopy.go
+++ b/pkg/apis/mirror/zz_generated.deepcopy.go
@@ -76,6 +76,11 @@ func (in *MirrorHost) DeepCopyInto(out *MirrorHost) {
 		*out = make([]MirrorHostCapability, len(*in))
 		copy(*out, *in)
 	}
+	if in.CABundle != nil {
+		in, out := &in.CABundle, &out.CABundle
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/webhook/mirror/ensurer.go
+++ b/pkg/webhook/mirror/ensurer.go
@@ -7,12 +7,17 @@ package mirror
 import (
 	"context"
 	"fmt"
+	"path"
 	"slices"
+	"strings"
 
+	"github.com/gardener/gardener/extensions/pkg/controller"
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	extensionscontextwebhook "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
+	"github.com/pelletier/go-toml/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -50,23 +55,10 @@ func (e *ensurer) EnsureCRIConfig(ctx context.Context, gctx extensionscontextweb
 		e.logger.Info("Shoot has a deletion timestamp set, skipping the OperatingSystemConfig mutation", "shoot", client.ObjectKeyFromObject(cluster.Shoot))
 		return nil
 	}
-	extension := &extensionsv1alpha1.Extension{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "registry-mirror",
-			Namespace: cluster.ObjectMeta.Name,
-		},
-	}
-	if err := e.client.Get(ctx, client.ObjectKeyFromObject(extension), extension); err != nil {
-		return fmt.Errorf("failed to get extension '%s': %w", client.ObjectKeyFromObject(extension), err)
-	}
 
-	if extension.Spec.ProviderConfig == nil {
-		return fmt.Errorf("extension '%s' does not have a .spec.providerConfig specified", client.ObjectKeyFromObject(extension))
-	}
-
-	mirrorConfig := &mirrorapi.MirrorConfig{}
-	if err := runtime.DecodeInto(e.decoder, extension.Spec.ProviderConfig.Raw, mirrorConfig); err != nil {
-		return fmt.Errorf("failed to decode providerConfig of extension '%s': %w", client.ObjectKeyFromObject(extension), err)
+	mirrorConfig, err := e.getMirrorConfigForCluster(ctx, cluster)
+	if err != nil {
+		return err
 	}
 
 	if newCRIConfig.Containerd == nil {
@@ -90,6 +82,9 @@ func (e *ensurer) EnsureCRIConfig(ctx context.Context, gctx extensionscontextweb
 					registryHost.Capabilities = append(registryHost.Capabilities, extensionsv1alpha1.ResolveCapability)
 				}
 			}
+			if len(host.CABundle) > 0 {
+				registryHost.CACerts = append(registryHost.CACerts, caFilename(mirror.Upstream, host.Host))
+			}
 			cfg.Hosts = append(cfg.Hosts, registryHost)
 		}
 		i := slices.IndexFunc(newCRIConfig.Containerd.Registries, func(registryConfig extensionsv1alpha1.RegistryConfig) bool {
@@ -103,4 +98,169 @@ func (e *ensurer) EnsureCRIConfig(ctx context.Context, gctx extensionscontextweb
 	}
 
 	return nil
+}
+func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newObj, _ *[]extensionsv1alpha1.File) error {
+	cluster, err := gctx.GetCluster(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get the cluster resource: %w", err)
+	}
+
+	if cluster.Shoot.DeletionTimestamp != nil {
+		e.logger.Info("Shoot has a deletion timestamp set, skipping the OperatingSystemConfig mutation", "shoot", client.ObjectKeyFromObject(cluster.Shoot))
+		return nil
+	}
+
+	mirrorConfig, err := e.getMirrorConfigForCluster(ctx, cluster)
+	if err != nil {
+		return err
+	}
+
+	for _, mirror := range mirrorConfig.Mirrors {
+		for _, caFile := range getCAFiles(mirror) {
+			*newObj = extensionswebhook.EnsureFileWithPath(*newObj, caFile)
+		}
+	}
+
+	return nil
+}
+
+func (e *ensurer) EnsureAdditionalProvisionFiles(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newObj, _ *[]extensionsv1alpha1.File) error {
+	cluster, err := gctx.GetCluster(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get the cluster resource: %w", err)
+	}
+
+	if cluster.Shoot.DeletionTimestamp != nil {
+		e.logger.Info("Shoot has a deletion timestamp set, skipping the OperatingSystemConfig mutation", "shoot", client.ObjectKeyFromObject(cluster.Shoot))
+		return nil
+	}
+
+	mirrorConfig, err := e.getMirrorConfigForCluster(ctx, cluster)
+	if err != nil {
+		return err
+	}
+
+	for _, mirror := range mirrorConfig.Mirrors {
+		if !mirror.ProvisionRelevant {
+			continue
+		}
+		err = ensureHostsConfig(mirror, newObj)
+		if err != nil {
+			return err
+		}
+		for _, caFile := range getCAFiles(mirror) {
+			*newObj = extensionswebhook.EnsureFileWithPath(*newObj, caFile)
+		}
+	}
+	return nil
+}
+
+type containerdConfig struct {
+	Server string                    `toml:"server" comment:"Created by gardener-extension-registry-mirror"`
+	Host   map[string]containerdHost `toml:"host"`
+}
+
+type containerdHost struct {
+	Capabilities []extensionsv1alpha1.RegistryCapability `toml:"capabilities"`
+	CA           string                                  `toml:"ca,omitempty"`
+}
+
+func (e *ensurer) getMirrorConfigForCluster(ctx context.Context, cluster *controller.Cluster) (*mirrorapi.MirrorConfig, error) {
+	extension := &extensionsv1alpha1.Extension{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "registry-mirror",
+			Namespace: cluster.ObjectMeta.Name,
+		},
+	}
+	if err := e.client.Get(ctx, client.ObjectKeyFromObject(extension), extension); err != nil {
+		return nil, fmt.Errorf("failed to get extension '%s': %w", client.ObjectKeyFromObject(extension), err)
+	}
+
+	if extension.Spec.ProviderConfig == nil {
+		return nil, fmt.Errorf("extension '%s' does not have a .spec.providerConfig specified", client.ObjectKeyFromObject(extension))
+	}
+
+	mirrorConfig := &mirrorapi.MirrorConfig{}
+	if err := runtime.DecodeInto(e.decoder, extension.Spec.ProviderConfig.Raw, mirrorConfig); err != nil {
+		return nil, fmt.Errorf("failed to decode providerConfig of extension '%s': %w", client.ObjectKeyFromObject(extension), err)
+	}
+	return mirrorConfig, nil
+}
+
+func ensureHostsConfig(config mirrorapi.MirrorConfiguration, files *[]extensionsv1alpha1.File) error {
+	cConfig := containerdConfig{
+		Server: registryutils.GetUpstreamURL(config.Upstream),
+		Host:   map[string]containerdHost{},
+	}
+
+	for _, host := range config.Hosts {
+		cHost := containerdHost{}
+		for _, c := range host.Capabilities {
+			switch c {
+			case mirrorapi.MirrorHostCapabilityPull:
+				cHost.Capabilities = append(cHost.Capabilities, extensionsv1alpha1.PullCapability)
+			case mirrorapi.MirrorHostCapabilityResolve:
+				cHost.Capabilities = append(cHost.Capabilities, extensionsv1alpha1.PullCapability)
+			}
+		}
+		if len(host.CABundle) > 0 {
+			cHost.CA = caFilename(config.Upstream, host.Host)
+		}
+		cConfig.Host[host.Host] = cHost
+	}
+
+	data, err := toml.Marshal(cConfig)
+	if err != nil {
+		return fmt.Errorf("failed to generate cConfig hosts.toml: %w", err)
+	}
+
+	hostsFile := extensionsv1alpha1.File{
+		Path:        path.Join(configBaseDir(config.Upstream), "hosts.toml"),
+		Permissions: ptr.To[uint32](0o644),
+		Content: extensionsv1alpha1.FileContent{
+			Inline: &extensionsv1alpha1.FileContentInline{
+				Encoding: "",
+				Data:     string(data),
+			},
+		},
+	}
+	*files = extensionswebhook.EnsureFileWithPath(*files, hostsFile)
+	return nil
+}
+
+func getCAFiles(config mirrorapi.MirrorConfiguration) []extensionsv1alpha1.File {
+	var files []extensionsv1alpha1.File
+	for _, host := range config.Hosts {
+		if len(host.CABundle) == 0 {
+			continue
+		}
+		caFile := extensionsv1alpha1.File{
+			Path:        caFilename(config.Upstream, host.Host),
+			Permissions: ptr.To[uint32](0o644),
+			Content: extensionsv1alpha1.FileContent{
+				Inline: &extensionsv1alpha1.FileContentInline{
+					Encoding: "b64",
+					Data:     string(host.CABundle),
+				},
+			},
+		}
+		files = extensionswebhook.EnsureFileWithPath(files, caFile)
+	}
+	return files
+}
+
+func caFilename(upstream, host string) string {
+	return path.Join(configBaseDir(upstream), hostname(host)+".crt")
+}
+
+func hostname(h string) string {
+	h = strings.TrimPrefix(h, "https://")
+	h = strings.TrimPrefix(h, "http://")
+	h = strings.TrimSuffix(h, "/")
+	return h
+}
+
+func configBaseDir(server string) string {
+	const baseDir = "/etc/containerd/certs.d"
+	return path.Join(baseDir, hostname(server))
 }

--- a/pkg/webhook/mirror/ensurer.go
+++ b/pkg/webhook/mirror/ensurer.go
@@ -6,6 +6,7 @@ package mirror
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"path"
 	"slices"
@@ -99,6 +100,7 @@ func (e *ensurer) EnsureCRIConfig(ctx context.Context, gctx extensionscontextweb
 
 	return nil
 }
+
 func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx extensionscontextwebhook.GardenContext, newObj, _ *[]extensionsv1alpha1.File) error {
 	cluster, err := gctx.GetCluster(ctx)
 	if err != nil {
@@ -240,7 +242,7 @@ func getCAFiles(config mirrorapi.MirrorConfiguration) []extensionsv1alpha1.File 
 			Content: extensionsv1alpha1.FileContent{
 				Inline: &extensionsv1alpha1.FileContentInline{
 					Encoding: "b64",
-					Data:     string(host.CABundle),
+					Data:     base64.StdEncoding.EncodeToString(host.CABundle),
 				},
 			},
 		}

--- a/pkg/webhook/mirror/ensurer_test.go
+++ b/pkg/webhook/mirror/ensurer_test.go
@@ -6,6 +6,7 @@ package mirror_test
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 
 	extensionscontextwebhook "github.com/gardener/gardener/extensions/pkg/webhook/context"
@@ -374,7 +375,6 @@ var _ = Describe("Ensurer", func() {
 			Expect(ensurer.EnsureAdditionalProvisionFiles(ctx, gctx, &files, nil)).To(Succeed())
 			Expect(files).To(ConsistOf(expectedFiles))
 		})
-
 	})
 
 	Describe("#EnsureAdditionalFiles", func() {
@@ -478,7 +478,7 @@ var _ = Describe("Ensurer", func() {
 					Content: extensionsv1alpha1.FileContent{
 						Inline: &extensionsv1alpha1.FileContentInline{
 							Encoding: "b64",
-							Data:     "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJiekNDQVNHZ0F3SUJBZ0lVUTdWd0QzOGdrcGpGaTBEU2krME9LTi9BVXRZd0JRWURLMlZ3TUJZeEZEQVMKQmdOVkJBTU1DMlY0WVcxd2JHVXVZMjl0TUI0WERUSTFNVEV5TlRFeE5EVTFORm9YRFRNMU1URXlNekV4TkRVMQpORm93RmpFVU1CSUdBMVVFQXd3TFpYaGhiWEJzWlM1amIyMHdLakFGQmdNclpYQURJUUQ1WWhacGk4QWZVUjJoCmFGbHhGNzN4SUpMZ2h1NjU0V0RNVlY5Zjh3Sk9EYU9CZ0RCK01CMEdBMVVkRGdRV0JCVHVGWWtXSW5LRUpnQlEKMFVTVk5jbmdxN3FwcWpBZkJnTlZIU01FR0RBV2dCVHVGWWtXSW5LRUpnQlEwVVNWTmNuZ3E3cXBxakFQQmdOVgpIUk1CQWY4RUJUQURBUUgvTUNzR0ExVWRFUVFrTUNLQ0MyVjRZVzF3YkdVdVkyOXRnZzBxTG1WNFlXMXdiR1V1ClkyOXRod1FLQUFBQk1BVUdBeXRsY0FOQkFESnFITE16a3hUVThwZTdZbHh2cU9qQkYxOEh4eGpwNFd1Z2tRcHMKNHFFZko0aHFRaGZERTl6Vm15K1R4RGhuT043Wng2UDB5K2QzZkhlV1YzK2ZtUXM9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
+							Data:     base64.StdEncoding.EncodeToString([]byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJiekNDQVNHZ0F3SUJBZ0lVUTdWd0QzOGdrcGpGaTBEU2krME9LTi9BVXRZd0JRWURLMlZ3TUJZeEZEQVMKQmdOVkJBTU1DMlY0WVcxd2JHVXVZMjl0TUI0WERUSTFNVEV5TlRFeE5EVTFORm9YRFRNMU1URXlNekV4TkRVMQpORm93RmpFVU1CSUdBMVVFQXd3TFpYaGhiWEJzWlM1amIyMHdLakFGQmdNclpYQURJUUQ1WWhacGk4QWZVUjJoCmFGbHhGNzN4SUpMZ2h1NjU0V0RNVlY5Zjh3Sk9EYU9CZ0RCK01CMEdBMVVkRGdRV0JCVHVGWWtXSW5LRUpnQlEKMFVTVk5jbmdxN3FwcWpBZkJnTlZIU01FR0RBV2dCVHVGWWtXSW5LRUpnQlEwVVNWTmNuZ3E3cXBxakFQQmdOVgpIUk1CQWY4RUJUQURBUUgvTUNzR0ExVWRFUVFrTUNLQ0MyVjRZVzF3YkdVdVkyOXRnZzBxTG1WNFlXMXdiR1V1ClkyOXRod1FLQUFBQk1BVUdBeXRsY0FOQkFESnFITE16a3hUVThwZTdZbHh2cU9qQkYxOEh4eGpwNFd1Z2tRcHMKNHFFZko0aHFRaGZERTl6Vm15K1R4RGhuT043Wng2UDB5K2QzZkhlV1YzK2ZtUXM9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K")),
 						},
 					},
 				},
@@ -487,6 +487,5 @@ var _ = Describe("Ensurer", func() {
 			Expect(ensurer.EnsureAdditionalFiles(ctx, gctx, &files, nil)).To(Succeed())
 			Expect(files).To(ConsistOf(expectedFiles))
 		})
-
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

This PR adds an option to specify a `Mirror` as `provisionRelevant`. This will add the mirror also as files in the `provision` `OperatingSystemConfig`. This is needed if the `Mirror` is relevant to pull the `gardener-node-agent`. We already use a similar setup, but we think it makes sense to have this in this extension.

After the `gardener-node-agent` is running the config will be maintained by the `gardener-node-agent` and updates the config if needed.

Additionally this adds the possibility to set a CA bundle for a `Mirror`.

Open points:
- [x] update docs

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
  Add possibibilty to use a mirror for provision relevant images. Which gets applied within the `provision` `OperatingSystemConfig`.
```
