### PR TITLE
Build OCI images on head update

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,6 @@ jobs:
 
   verify:
     runs-on: ubuntu-latest
-    if: ${{ inputs.mode == 'release' }}
     permissions:
       contents: read
     steps:
@@ -40,11 +39,16 @@ jobs:
 
           mkdir -p /tmp/blobs.d
 
-          make verify-extended |& tee /tmp/blobs.d/verify-log.txt
-
-          tar czf /tmp/blobs.d/gosec-report.tar.gz gosec-report.sarif
-          tar czf /tmp/blobs.d/verify-log.tar.gz -C /tmp/blobs.d verify-log.txt
-
+          # For non-release runs, make verify-extended is executed in Prow.
+          # Execute make verify-extended only for release runs.
+          if [ '${{ inputs.mode }}' == 'release' ]; then
+            make verify-extended |& tee /tmp/blobs.d/verify-log.txt
+            tar czf /tmp/blobs.d/gosec-report.tar.gz gosec-report.sarif
+            tar czf /tmp/blobs.d/verify-log.tar.gz -C /tmp/blobs.d verify-log.txt
+          else
+            echo "dummy" > /tmp/blobs.d/gosec-report.tar.gz
+            echo "dummy" > /tmp/blobs.d/verify-log.tar.gz
+          fi
       - name: Add results to component descriptor
         uses: gardener/cc-utils/.github/actions/export-ocm-fragments@master
         with:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug
/kind regression

**What this PR does / why we need it**:
After https://github.com/gardener/gardener-extension-registry-cache/pull/507 we no longer build OCI images on head update. The reason seems to be the skip in https://github.com/gardener/gardener-extension-registry-cache/blob/2b8f817d33d7c60efee323e80ab16e58e25a203d/.github/workflows/build.yaml#L25.

According to ChatGPT:
> If a job or step that is needed is skipped (e.g., due to an `if:` condition evaluating to false or a paths filter), then **the dependent job will also be skipped** by default. This is normal behavior in GitHub Actions’ dependency resolution. [ref](https://github.com/orgs/community/discussions/25224?utm_source=chatgpt.com#discussioncomment-3246940)

This PR moves the if statement to the job itself - the way it was before https://github.com/gardener/gardener-extension-registry-cache/pull/507.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-registry-cache/pull/507

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
