### PR TITLE
Revert recent securityContext changes for the registry cache StatefulSet

### DIFF
--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -356,7 +356,6 @@ func (r *registryCaches) registryCacheObjects(ctx context.Context, cache *regist
 					AutomountServiceAccountToken: ptr.To(false),
 					PriorityClassName:            "system-cluster-critical",
 					SecurityContext: &corev1.PodSecurityContext{
-						FSGroup: ptr.To(int64(65532)),
 						SeccompProfile: &corev1.SeccompProfile{
 							Type: corev1.SeccompProfileTypeRuntimeDefault,
 						},
@@ -417,9 +416,6 @@ source /entrypoint.sh /etc/distribution/config.yml
 							},
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: ptr.To(false),
-								RunAsNonRoot:             ptr.To(true),
-								RunAsUser:                ptr.To(int64(65532)),
-								RunAsGroup:               ptr.To(int64(65532)),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{
 										"ALL",

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -322,7 +322,6 @@ proxy:
 								AutomountServiceAccountToken: ptr.To(false),
 								PriorityClassName:            "system-cluster-critical",
 								SecurityContext: &corev1.PodSecurityContext{
-									FSGroup: ptr.To(int64(65532)),
 									SeccompProfile: &corev1.SeccompProfile{
 										Type: corev1.SeccompProfileTypeRuntimeDefault,
 									},
@@ -373,9 +372,6 @@ source /entrypoint.sh /etc/distribution/config.yml
 										Env: env,
 										SecurityContext: &corev1.SecurityContext{
 											AllowPrivilegeEscalation: ptr.To(false),
-											RunAsNonRoot:             ptr.To(true),
-											RunAsUser:                ptr.To(int64(65532)),
-											RunAsGroup:               ptr.To(int64(65532)),
 											Capabilities: &corev1.Capabilities{
 												Drop: []corev1.Capability{
 													"ALL",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR revert the recent securityContext changes for the registry cache StatefulSet from https://github.com/gardener/gardener-extension-registry-cache/pull/473.
https://github.com/gardener/gardener-extension-registry-cache/pull/473 adds `fsGroup: 65532` to the registry cache StatefulSet. 
In https://github.com/gardener/gardener-extension-registry-cache/issues/516, we want to first carefully test the performance implications of this change and to apply it later on with or without `fsGroupChangePolicy: OnRootMismatch`. This most likely will happen for the v0.21.0 release.
We agreed to temporarily revert these changes to unblock the v0.20.0 release.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-registry-cache/pull/473
Related to https://github.com/gardener/gardener-extension-registry-cache/issues/516

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
