### PR TITLE
Reintroduce the recent securityContext changes for the registry cache StatefulSet

### DIFF
--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -356,7 +356,8 @@ func (r *registryCaches) registryCacheObjects(ctx context.Context, cache *regist
 					AutomountServiceAccountToken: ptr.To(false),
 					PriorityClassName:            "system-cluster-critical",
 					SecurityContext: &corev1.PodSecurityContext{
-						FSGroup: ptr.To(int64(65532)),
+						FSGroup:             ptr.To(int64(65532)),
+						FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 						SeccompProfile: &corev1.SeccompProfile{
 							Type: corev1.SeccompProfileTypeRuntimeDefault,
 						},

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -322,7 +322,8 @@ proxy:
 								AutomountServiceAccountToken: ptr.To(false),
 								PriorityClassName:            "system-cluster-critical",
 								SecurityContext: &corev1.PodSecurityContext{
-									FSGroup: ptr.To(int64(65532)),
+									FSGroup:             ptr.To(int64(65532)),
+									FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeOnRootMismatch),
 									SeccompProfile: &corev1.SeccompProfile{
 										Type: corev1.SeccompProfileTypeRuntimeDefault,
 									},


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR reverts commit `6bcc87e6f71908d2b9bb611b193ecdb9c6b2c680` from #534 and reintroduce the recent securityContext changes for the registry cache StatefulSet from #437.

No significant performance regression is observed in #516

**Which issue(s) this PR fixes**:
Related to #516

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
