### PR TITLE
Update the `github.com/gardener/gardener/pkg/apis` dependency as well when updating `github.com/gardener/gardener`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,12 @@ updates:
   open-pull-requests-limit: 5
   allow:
   - dependency-name: "github.com/gardener/gardener"
+  - dependency-name: "github.com/gardener/gardener/pkg/apis"
+  groups:
+    gardener:
+      patterns:
+      - "github.com/gardener/gardener"
+      - "github.com/gardener/gardener/pkg/apis"
   labels:
   - kind/enhancement
 # Create PRs for golang version updates


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
In https://github.com/gardener/gardener-extension-registry-cache/pull/542, the newly introduced `github.com/gardener/gardener/pkg/apis` submodule was not updated when dependabot raised PR for updating `github.com/gardener/gardener`. The version of the `github.com/gardener/gardener/pkg/apis` submodule should be in sync with `github.com/gardener/gardener`.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-registry-cache/pull/541

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
