### PR TITLE
Clean up unused imports from `hack/tools.go`

### DIFF
--- a/hack/tools.go
+++ b/hack/tools.go
@@ -9,10 +9,7 @@
 package tools
 
 import (
-	_ "github.com/gardener/gardener/.github"
-	_ "github.com/gardener/gardener/.github/ISSUE_TEMPLATE"
 	_ "github.com/gardener/gardener/hack"
-	_ "github.com/gardener/gardener/hack/.ci"
 	_ "github.com/gardener/gardener/hack/api-reference/template"
 	_ "github.com/gardener/gardener/hack/tools/logcheck/plugin"
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup

**What this PR does / why we need it**:
These imports are unused after https://github.com/gardener/gardener-extension-registry-cache/pull/147.
With https://github.com/gardener/gardener-extension-registry-cache/pull/147 we no longer copy PR templates or issues templates from `github.com/gardener/gardener/.github` and we no longer invoke scripts from `github.com/gardener/gardener/hack/.ci`. Instead, back then we just copied these scripts. 

The copied scripts in `.ci/third_party/` were later on removed with the migration to GitHub Actions.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
