### PR TITLE
admission: Prevent leaking the validatingwebhookconfiguration resource in virtual garden cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,9 @@ extension-dev: $(SKAFFOLD) $(HELM) $(KUBECTL)
 
 extension-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) delete
-	@# The validating webhook is not part of the chart but it is created on admission Pod startup. Hence, we have to delete it explicitly.
+	@# The validating webhook is not part of the chart but it is created on admission Pod startup.
+	@# The approach with the owner Namespace ("--webhook-config-owner-namespace") cannot be used here as the extension is not managed via the operator in this setup.
+	@# Hence, we have to delete the webhook explicitly.
 	$(KUBECTL) delete validatingwebhookconfiguration gardener-extension-registry-cache-admission --ignore-not-found
 
 remote-extension-up remote-extension-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=extension-remote
@@ -155,7 +157,9 @@ remote-extension-up: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ)
 
 remote-extension-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(SKAFFOLD) delete
-	@# The validating webhook is not part of the chart but it is created on admission Pod startup. Hence, we have to delete it explicitly.
+	@# The validating webhook is not part of the chart but it is created on admission Pod startup.
+	@# The approach with the owner Namespace ("--webhook-config-owner-namespace") cannot be used here as the extension is not managed via the operator in this setup.
+	@# Hence, we have to delete the webhook explicitly.
 	$(KUBECTL) delete validatingwebhookconfiguration gardener-extension-registry-cache-admission --ignore-not-found
 
 extension-operator-up extension-operator-down: export SKAFFOLD_FILENAME = skaffold-operator.yaml

--- a/charts/admission/charts/runtime/templates/deployment.yaml
+++ b/charts/admission/charts/runtime/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
         - --webhook-config-mode=service
         {{- end}}
         - --webhook-config-namespace={{ .Release.Namespace }}
+        {{- if .Values.gardener.virtualCluster.namespace }}
+        - --webhook-config-owner-namespace={{ .Values.gardener.virtualCluster.namespace }}
+        {{- end }}
         {{- if .Values.kubeconfig }}
         - --kubeconfig=/kubeconfig/kubeconfig
         {{- end }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/area quality
/kind bug

**What this PR does / why we need it**:
Similar to https://github.com/gardener/gardener-extension-otelcol/pull/68/changes/65f861bbe751b62cf5e69168b0a1d3507f3ac2bd.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/14334

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The registry-cache-admission's validatingwebhookconfiguration is no longer leaking in the virtual cluster when the registry-cache operator.gardener.cloud/v1alpha1.Extension resource is deleted.
```
