### PR TITLE
admission: Allow deletion of the ValidatingWebhookConfiguration

### DIFF
--- a/charts/admission/charts/application/templates/rbac.yaml
+++ b/charts/admission/charts/application/templates/rbac.yaml
@@ -38,6 +38,7 @@ rules:
   verbs:
   - patch
   - update
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/kind regression

**What this PR does / why we need it**:
https://github.com/gardener/gardener-extension-registry-cache/pull/550 introduces the following issue to the admission component:
```
Error: retry failed with context deadline exceeded, last error: error reconciling seed webhook config: error reconciling seed webhook config: validatingwebhookconfigurations.admissionregistration.k8s.io "gardener-extension-registry-cache-admission" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>
Usage:
  gardener-extension-registry-cache-admission [flags]

Flags:
   # Omitted

{"level":"error","ts":"2026-03-23T16:05:58.273Z","msg":"Error executing the main controller command","error":"retry failed with context deadline exceeded, last error: error reconciling seed webhook config: error reconciling seed webhook config: validatingwebhookconfigurations.admissionregistration.k8s.io \"gardener-extension-registry-cache-admission\" is forbidden: cannot set an ownerRef on a resource you can't delete: , <nil>","stacktrace":"main.main\n\t/go/src/github.com/gardener/gardener-extension-registry-cache/cmd/gardener-extension-registry-cache-admission/main.go:22\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:290"}
```

The issue occurs when the [`OwnerReferencesPermissionEnforcement`](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) admission plugin is enabled for the virtual Kubernetes API server.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-registry-cache/pull/550
Part of https://github.com/gardener/gardener/issues/13006

**Special notes for your reviewer**:
Steps to reproduce and steps to verify the fix:
```
# Navigate to gardener/gardener
make kind-multi-zone-up operator-up
make operator-seed-up

# Enable the OwnerReferencesPermissionEnforcement admission plugin
kubectl patch garden local --type=merge --patch='{"spec":{"virtualCluster":{"kubernetes":{"kubeAPIServer":{"admissionPlugins":[{"name":"OwnerReferencesPermissionEnforcement"}]}}}}}'

# Navigate to gardener/gardener-extension-registry-cache
export KUBECONFIG=../gardener/example/gardener-local/kind/multi-zone/kubeconfig
make extension-operator-up

# Ensure the extension admission Pods fail or succeed to patch the ownerReference
# Have in mind that the OwnerReferencesPermissionEnforcement does not consider CREATE requests - see https://github.com/kubernetes/kubernetes/blob/eca347edbf5883b80c43a400120a5f3b99cf9efb/plugin/pkg/admission/gc/gc_admission.go#L100-L102
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
