### PR TITLE
Set `SkipSeedInitialization` for TM tests

### DIFF
--- a/test/testmachinery/shoot/enable_disable_test.go
+++ b/test/testmachinery/shoot/enable_disable_test.go
@@ -25,7 +25,9 @@ const (
 
 var _ = Describe("Shoot registry cache testing", func() {
 	var (
-		f = framework.NewShootFramework(nil)
+		f = framework.NewShootFramework(&framework.ShootConfig{
+			SkipSeedInitialization: true,
+		})
 
 		isVerticalPodAutoscalerDisabled bool
 	)

--- a/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
+++ b/test/testmachinery/shoot/enable_hibernate_reconcile_wakeup_disable_test.go
@@ -26,7 +26,9 @@ const (
 
 var _ = Describe("Shoot registry cache testing", func() {
 	var (
-		f = framework.NewShootFramework(nil)
+		f = framework.NewShootFramework(&framework.ShootConfig{
+			SkipSeedInitialization: true,
+		})
 
 		isVerticalPodAutoscalerDisabled bool
 		isShootHibernated               bool

--- a/test/testmachinery/shoot/enable_rotate_ca_disable_test.go
+++ b/test/testmachinery/shoot/enable_rotate_ca_disable_test.go
@@ -27,7 +27,9 @@ const (
 
 var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 	var (
-		f = framework.NewShootFramework(nil)
+		f = framework.NewShootFramework(&framework.ShootConfig{
+			SkipSeedInitialization: true,
+		})
 
 		isVerticalPodAutoscalerDisabled bool
 	)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
See https://github.com/gardener/gardener-extension-registry-cache/issues/519

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-registry-cache/issues/519

**Special notes for your reviewer**:
The output of running the TM tests based on this PR:
```
% go test -timeout=0 ./test/testmachinery/shoot \
  --v -ginkgo.v -ginkgo.show-node-events -ginkgo.no-color \
  -kubecfg=$TM_KUBECONFIG_PATH/gardener.config \
  -project-namespace=$PROJECT_NAMESPACE \
  -shoot-name=$SHOOT_NAME \
  -ginkgo.focus="\[SERIAL\]" \
  -ginkgo.skip="\[DISRUPTIVE\]" \
  -ginkgo.timeout=9000s

# ...

Ran 3 of 3 Specs in 3273.520 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestShoot (3273.52s)
PASS
ok  	github.com/gardener/gardener-extension-registry-cache/test/testmachinery/shoot	3275.338s
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
