### PR TITLE
Clean up the `OTEL_TRACES_EXPORTER` env var mitigation

### DIFF
--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -410,13 +410,6 @@ source /entrypoint.sh /etc/distribution/config.yml
 									Name:          "debug",
 								},
 							},
-							Env: []corev1.EnvVar{
-								// Mitigation for https://github.com/distribution/distribution/issues/4270.
-								{
-									Name:  "OTEL_TRACES_EXPORTER",
-									Value: "none",
-								},
-							},
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: ptr.To(false),
 								RunAsNonRoot:             ptr.To(true),

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -279,15 +279,7 @@ proxy:
 				return config
 			}
 
-			statefulSetFor = func(name, upstream, size, configSecretName string, tlsEnabled bool, tlsSecretName string, storageClassName *string, additionalEnvs []corev1.EnvVar, haEnabled bool) *appsv1.StatefulSet {
-				env := []corev1.EnvVar{
-					{
-						Name:  "OTEL_TRACES_EXPORTER",
-						Value: "none",
-					},
-				}
-				env = append(env, additionalEnvs...)
-
+			statefulSetFor = func(name, upstream, size, configSecretName string, tlsEnabled bool, tlsSecretName string, storageClassName *string, env []corev1.EnvVar, haEnabled bool) *appsv1.StatefulSet {
 				statefulSet := &appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
@@ -654,7 +646,7 @@ source /entrypoint.sh /etc/distribution/config.yml
 
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 
-				additionalEnvs := []corev1.EnvVar{
+				env := []corev1.EnvVar{
 					{
 						Name:  "HTTP_PROXY",
 						Value: "http://127.0.0.1",
@@ -676,10 +668,10 @@ source /entrypoint.sh /etc/distribution/config.yml
 					networkPolicy,
 					dockerConfigSecret,
 					dockerTLSSecret,
-					statefulSetFor("registry-docker-io", "docker.io", "10Gi", dockerConfigSecret.Name, true, dockerTLSSecret.Name, nil, additionalEnvs, false),
+					statefulSetFor("registry-docker-io", "docker.io", "10Gi", dockerConfigSecret.Name, true, dockerTLSSecret.Name, nil, env, false),
 					vpaFor("registry-docker-io"),
 					arConfigSecret,
-					statefulSetFor("registry-europe-docker-pkg-dev", "europe-docker.pkg.dev", "20Gi", arConfigSecret.Name, false, "", ptr.To("premium"), additionalEnvs, false),
+					statefulSetFor("registry-europe-docker-pkg-dev", "europe-docker.pkg.dev", "20Gi", arConfigSecret.Name, false, "", ptr.To("premium"), env, false),
 					vpaFor("registry-europe-docker-pkg-dev"),
 				))
 			})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
The mitigation for https://github.com/distribution/distribution/issues/4270 is no longer needed with registry 3.1.0 (https://github.com/gardener/gardener-extension-registry-cache/pull/564).
See https://github.com/gardener/gardener-extension-registry-cache/pull/564#discussion_r3098437371.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-registry-cache/issues/558

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
