### PR TITLE
Replace Gardener `provider-extensions` setup with Gardener `remote` setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,8 @@ IMAGE_TAG                   := $(EFFECTIVE_VERSION)
 LD_FLAGS                    := "-w $(shell bash $(GARDENER_HACK_DIR)/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION $(NAME))"
 PARALLEL_E2E_TESTS          := 3
 GARDENER_REPO_ROOT          ?= $(REPO_ROOT)/../gardener
-SEED_NAME                   := provider-extensions
-SEED_KUBECONFIG             := $(GARDENER_REPO_ROOT)/example/provider-extensions/seed/kubeconfig
+RUNTIME_KUBECONFIG          := $(GARDENER_REPO_ROOT)/dev-setup/kubeconfigs/runtime/kubeconfig
 
-ifneq ($(SEED_NAME),provider-extensions)
-	SEED_KUBECONFIG := $(GARDENER_REPO_ROOT)/example/provider-extensions/seed/kubeconfig-$(SEED_NAME)
-endif
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
 	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
 endif
@@ -151,20 +147,16 @@ extension-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(KUBECTL) delete validatingwebhookconfiguration gardener-extension-registry-cache-admission --ignore-not-found
 
 remote-extension-up remote-extension-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=extension-remote
+extension-operator-up extension-operator-down remote-extension-up remote-extension-down: export SKAFFOLD_FILENAME = skaffold-operator.yaml
 
 remote-extension-up: $(SKAFFOLD) $(HELM) $(KUBECTL) $(YQ)
-	@LD_FLAGS=$(LD_FLAGS) ./hack/remote-extension-up.sh --path-seed-kubeconfig $(SEED_KUBECONFIG)
+	@LD_FLAGS=$(LD_FLAGS) GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) ./hack/remote-extension-up.sh --path-runtime-kubeconfig $(RUNTIME_KUBECONFIG)
 
 remote-extension-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
-	$(SKAFFOLD) delete
-	@# The validating webhook is not part of the chart but it is created on admission Pod startup.
-	@# The approach with the owner Namespace ("--webhook-config-owner-namespace") cannot be used here as the extension is not managed via the operator in this setup.
-	@# Hence, we have to delete the webhook explicitly.
-	$(KUBECTL) delete validatingwebhookconfiguration gardener-extension-registry-cache-admission --ignore-not-found
+	$(SKAFFOLD) delete -p remote --kubeconfig=$(RUNTIME_KUBECONFIG)
 
-extension-operator-up extension-operator-down: export SKAFFOLD_FILENAME = skaffold-operator.yaml
 extension-operator-up: $(SKAFFOLD) $(KIND) $(HELM) $(KUBECTL)
-	@LD_FLAGS=$(LD_FLAGS) GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) $(SKAFFOLD) run
+	@LD_FLAGS=$(LD_FLAGS) GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) $(SKAFFOLD) run --kubeconfig=$(RUNTIME_KUBECONFIG)
 
 extension-operator-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
-	$(SKAFFOLD) delete
+	$(SKAFFOLD) delete --kubeconfig=$(RUNTIME_KUBECONFIG)

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ LD_FLAGS                    := "-w $(shell bash $(GARDENER_HACK_DIR)/get-build-l
 PARALLEL_E2E_TESTS          := 3
 GARDENER_REPO_ROOT          ?= $(REPO_ROOT)/../gardener
 RUNTIME_KUBECONFIG          := $(GARDENER_REPO_ROOT)/dev-setup/kubeconfigs/runtime/kubeconfig
+LOCAL_KIND_KUBECONFIG       := $(GARDENER_REPO_ROOT)/example/gardener-local/kind/local/kubeconfig
 
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
 	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
@@ -134,17 +135,17 @@ export SKAFFOLD_PUSH = true
 export SKAFFOLD_LABEL = skaffold.dev/run-id=extension-local
 
 extension-up: $(SKAFFOLD) $(KIND) $(HELM) $(KUBECTL)
-	@LD_FLAGS=$(LD_FLAGS) $(SKAFFOLD) run
+	@LD_FLAGS=$(LD_FLAGS) $(SKAFFOLD) run --kubeconfig=$(LOCAL_KIND_KUBECONFIG)
 
 extension-dev: $(SKAFFOLD) $(HELM) $(KUBECTL)
-	$(SKAFFOLD) dev --cleanup=false --trigger=manual
+	$(SKAFFOLD) dev --cleanup=false --trigger=manual --kubeconfig=$(LOCAL_KIND_KUBECONFIG)
 
 extension-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
-	$(SKAFFOLD) delete
+	$(SKAFFOLD) delete --kubeconfig=$(LOCAL_KIND_KUBECONFIG)
 	@# The validating webhook is not part of the chart but it is created on admission Pod startup.
 	@# The approach with the owner Namespace ("--webhook-config-owner-namespace") cannot be used here as the extension is not managed via the operator in this setup.
 	@# Hence, we have to delete the webhook explicitly.
-	$(KUBECTL) delete validatingwebhookconfiguration gardener-extension-registry-cache-admission --ignore-not-found
+	$(KUBECTL) delete validatingwebhookconfiguration gardener-extension-registry-cache-admission --ignore-not-found --kubeconfig=$(LOCAL_KIND_KUBECONFIG)
 
 remote-extension-up remote-extension-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=extension-remote
 extension-operator-up extension-operator-down remote-extension-up remote-extension-down: export SKAFFOLD_FILENAME = skaffold-operator.yaml

--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ Gardener extension controller which deploys pull-through caches for container re
 ## Local Setup and Development
 
 - [Deploying Registry Cache Extension Locally](docs/development/getting-started-locally.md) - learn how to set up a local development environment
-- [Deploying Registry Cache Extension in Gardener's Local Setup with Provider Extensions](docs/development/getting-started-remotely.md) - learn how to set up a development environment using own Seed clusters on an existing Kubernetes cluster
+- [Deploying Registry Cache Extension in Gardener's Remote Setup](docs/development/getting-started-remotely.md) - learn how to set up a remote development environment using an existing Kubernetes cluster
 - [Developer Docs for Gardener Extension Registry Cache](docs/development/extension-registry-cache.md) - learn about the inner workings

--- a/docs/development/getting-started-locally.md
+++ b/docs/development/getting-started-locally.md
@@ -7,15 +7,19 @@ description: Learn how to set up a local development environment
 
 ## Prerequisites
 
-- Make sure that you have a running local Gardener setup. The steps to complete this can be found in the [Deploying Gardener Locally guide](https://github.com/gardener/gardener/blob/v1.140.0/docs/deployment/getting_started_locally.md).
+- Make sure that you have a running local Gardener setup. The steps to complete this can be found in the [Deploying Gardener Locally guide](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md).
 
 > [!TIP]
 > Ensure that the locally used Gardener version matches the version specified by the `github.com/gardener/gardener` dependency.
 > The extension’s local setup must run successfully against a local Gardener setup at the version referenced by this dependency, as verified by end-to-end tests.
 
-## Setting up the Registry Cache Extension
+> [!NOTE]
+> The location of the Gardener project is expected to be under the same root (e.g. `~/go/src/github.com/gardener/`). If this is not the case, the location of Gardener project should be specified in `GARDENER_REPO_ROOT` environment variable:
+> ```bash
+> export GARDENER_REPO_ROOT="<path_to_gardener_project>"
+> ```
 
-Make sure that your `KUBECONFIG` environment variable is targeting the local Gardener cluster. When this is ensured, run:
+## Setting up the Registry Cache Extension
 
 ```bash
 make extension-up
@@ -26,6 +30,9 @@ The corresponding make target will build the extension image, load it into the k
 The make target will then deploy the registry-cache admission component. It will build the admission image, load it into the kind cluster Nodes, and finally install the admission component charts to the kind cluster.
 
 ## Creating a Shoot Cluster
+
+> [!NOTE]
+> Make sure that your `KUBECONFIG` environment variable is targeting the local Gardener cluster (i.e. `<path_to_gardener_project>/example/gardener-local/kind/local/kubeconfig`).
 
 Once the above step is completed, you can create a Shoot cluster.
 
@@ -51,7 +58,17 @@ The make target will delete the ControllerDeployment and ControllerRegistration 
 
 ## Alternative Setup Using the `gardener-operator` Local Setup
 
-Alternatively, you can deploy the registry-cache extension in the `gardener-operator` local setup. To do this, make sure you are have a running local setup based on [Alternative Way to Set Up Garden and Seed Leveraging `gardener-operator`](https://github.com/gardener/gardener/blob/v1.140.0/docs/deployment/getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator).
+Alternatively, you can deploy the registry-cache extension in the `gardener-operator` local setup. To do this, make sure you have a running local setup based on [Alternative Way to Set Up Garden and Seed Leveraging `gardener-operator`](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator).
+
+> [!TIP]
+> Ensure that the locally used Gardener version matches the version specified by the `github.com/gardener/gardener` dependency.
+> The extension’s operator setup must run successfully against a Gardener operator setup at the version referenced by this dependency.
+
+> [!NOTE]
+> The location of the Gardener project is expected to be under the same root (e.g. `~/go/src/github.com/gardener/`). If this is not the case, the location of Gardener project should be specified in `GARDENER_REPO_ROOT` environment variable:
+> ```bash
+> export GARDENER_REPO_ROOT="<path_to_gardener_project>"
+> ```
 
 #### Creating the registry-cache `Extension.operator.gardener.cloud` resource:
 

--- a/docs/development/getting-started-locally.md
+++ b/docs/development/getting-started-locally.md
@@ -7,7 +7,7 @@ description: Learn how to set up a local development environment
 
 ## Prerequisites
 
-- Make sure that you have a running local Gardener setup. The steps to complete this can be found in the [Deploying Gardener Locally guide](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md).
+- Make sure that you have a running local Gardener setup. The steps to complete this can be found in the [Deploying Gardener Locally guide](https://github.com/gardener/gardener/blob/v1.140.0/docs/deployment/getting_started_locally.md).
 
 > [!TIP]
 > Ensure that the locally used Gardener version matches the version specified by the `github.com/gardener/gardener` dependency.
@@ -51,7 +51,7 @@ The make target will delete the ControllerDeployment and ControllerRegistration 
 
 ## Alternative Setup Using the `gardener-operator` Local Setup
 
-Alternatively, you can deploy the registry-cache extension in the `gardener-operator` local setup. To do this, make sure you are have a running local setup based on [Alternative Way to Set Up Garden and Seed Leveraging `gardener-operator`](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator). The `KUBECONFIG` environment variable should target the operator local KinD cluster (i.e. `<path_to_gardener_project>/dev-setup/kubeconfigs/runtime/kubeconfig`).
+Alternatively, you can deploy the registry-cache extension in the `gardener-operator` local setup. To do this, make sure you are have a running local setup based on [Alternative Way to Set Up Garden and Seed Leveraging `gardener-operator`](https://github.com/gardener/gardener/blob/v1.140.0/docs/deployment/getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator).
 
 #### Creating the registry-cache `Extension.operator.gardener.cloud` resource:
 
@@ -63,14 +63,18 @@ The corresponding make target will build the registry-cache admission and extens
 
 #### Creating a Shoot Cluster
 
-To create a Shoot cluster the `KUBECONFIG` environment variable should target virtual garden cluster (i.e. `<path_to_gardener_project>/dev-setup/kubeconfigs/virtual-garden/kubeconfig`) and then execute:
+> [!NOTE]
+> Make sure that your `KUBECONFIG` environment variable is targeting the virtual Garden cluster (i.e. `<path_to_gardener_project>/dev-setup/kubeconfigs/virtual-garden/kubeconfig`).
+
+To create a Shoot cluster execute:
 ```bash
 kubectl create -f example/shoot-registry-cache.yaml
 ```
 
 #### Delete the registry-cache `Extension.operator.gardener.cloud` resource
 
-Make sure the environment variable `KUBECONFIG` points to the operator's local KinD cluster and then run:
+To tear down the development environment, delete the Shoot cluster or disable the `registry-cache` extension in the Shoot's specification. When the extension is not used by the Shoot anymore, you can run:
+
 ```bash
 make extension-operator-down
 ```

--- a/docs/development/getting-started-locally.md
+++ b/docs/development/getting-started-locally.md
@@ -60,16 +60,6 @@ The make target will delete the ControllerDeployment and ControllerRegistration 
 
 Alternatively, you can deploy the registry-cache extension in the `gardener-operator` local setup. To do this, make sure you have a running local setup based on [Alternative Way to Set Up Garden and Seed Leveraging `gardener-operator`](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#alternative-way-to-set-up-garden-and-seed-leveraging-gardener-operator).
 
-> [!TIP]
-> Ensure that the locally used Gardener version matches the version specified by the `github.com/gardener/gardener` dependency.
-> The extension’s operator setup must run successfully against a Gardener operator setup at the version referenced by this dependency.
-
-> [!NOTE]
-> The location of the Gardener project is expected to be under the same root (e.g. `~/go/src/github.com/gardener/`). If this is not the case, the location of Gardener project should be specified in `GARDENER_REPO_ROOT` environment variable:
-> ```bash
-> export GARDENER_REPO_ROOT="<path_to_gardener_project>"
-> ```
-
 #### Creating the registry-cache `Extension.operator.gardener.cloud` resource:
 
 ```bash

--- a/docs/development/getting-started-remotely.md
+++ b/docs/development/getting-started-remotely.md
@@ -1,21 +1,19 @@
 ---
-title: Deploying Registry Cache Extension in Gardener's Local Setup with Provider Extensions
-description: Learn how to set up a development environment using own Seed clusters on an existing Kubernetes cluster
+title: Deploying Registry Cache Extension in Gardener's Remote Setup
+description: Learn how to set up a remote development environment using an existing Kubernetes cluster
 ---
 
-# Deploying Registry Cache Extension in Gardener's Local Setup with Provider Extensions
+# Deploying Registry Cache Extension in Gardener's Remote Setup
 
 ## Prerequisites
 
-- Make sure that you have a running local Gardener setup with enabled provider extensions. The steps to complete this can be found in the [Deploying Gardener Locally and Enabling Provider-Extensions](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally_with_extensions.md) guide.
+- Make sure that you have a running Gardener remote setup. The steps to complete this can be found in the [Deploying Gardener Remotely](https://github.com/gardener/gardener/blob/v1.140.0/docs/deployment/getting_started_remotely.md) guide.
 
 > [!TIP]
 > Ensure that the locally used Gardener version matches the version specified by the `github.com/gardener/gardener` dependency.
-> The extension’s local setup must run successfully against a local Gardener setup at the version referenced by this dependency.
+> The extension’s remote setup must run successfully against a Gardener remote setup at the version referenced by this dependency.
 
 ## Setting up the Registry Cache Extension
-
-Make sure that your `KUBECONFIG` environment variable is targeting the local Gardener cluster.
 
 The location of the Gardener project from the Gardener setup step is expected to be under the same root (e.g. `~/go/src/github.com/gardener/`). If this is not the case, the location of Gardener project should be specified in `GARDENER_REPO_ROOT` environment variable:
 
@@ -29,18 +27,13 @@ Then you can run:
 make remote-extension-up
 ```
 
-In case you have added additional Seeds you can specify the seed name:
-
-```bash
-make remote-extension-up SEED_NAME=<seed-name>
-```
-
-The corresponding make target will build the extension image, push it into the Seed cluster image registry, and deploy the registry-cache ControllerDeployment and ControllerRegistration resources into the kind cluster.
-The container image in the ControllerDeployment will be the image that was build and pushed into the Seed cluster image registry.
-
-The make target will then deploy the registry-cache admission component. It will build the admission image, push it into the kind cluster image registry, and finally install the admission component charts to the kind cluster.
+The corresponding make target will build the registry-cache admission and extension container images, OCI artifacts for the admission runtime and application charts, and the extension chart. Then, the container images and the OCI artifacts are pushed into the container registry in the remote Gardener cluster.
+Next, the gardener-extension-registry-cache `Extension.operator.gardener.cloud` resource is deployed into the Gardener runtime cluster. Based on this resource the gardener-operator will deploy the registry-cache admission component in the Gardener runtime cluster, as well as the registry-cache ControllerDeployment and ControllerRegistration resources in the virtual Gardener cluster.
 
 ## Creating a Shoot Cluster
+
+> [!NOTE]
+> Make sure that your `KUBECONFIG` environment variable is targeting the virtual Garden cluster (i.e. `<path_to_gardener_project>/dev-setup/kubeconfigs/virtual-garden/kubeconfig`).
 
 Once the above step is completed, you can create a Shoot cluster. In order to create a Shoot cluster, please create your own Shoot definition depending on providers on your Seed cluster.
 
@@ -52,4 +45,4 @@ To tear down the development environment, delete the Shoot cluster or disable th
 make remote-extension-down
 ```
 
-The make target will delete the ControllerDeployment and ControllerRegistration of the extension, and the registry-cache admission helm deployment.
+The corresponding make target will delete the `Extension.operator.gardener.cloud` resource. Consequently, the gardener-operator will delete the registry-cache admission component and registry-cache ControllerDeployment and ControllerRegistration resources.

--- a/docs/development/getting-started-remotely.md
+++ b/docs/development/getting-started-remotely.md
@@ -7,21 +7,19 @@ description: Learn how to set up a remote development environment using an exist
 
 ## Prerequisites
 
-- Make sure that you have a running Gardener remote setup. The steps to complete this can be found in the [Deploying Gardener Remotely](https://github.com/gardener/gardener/blob/v1.140.0/docs/deployment/getting_started_remotely.md) guide.
+- Make sure that you have a running Gardener remote setup. The steps to complete this can be found in the [Deploying Gardener Remotely](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_remotely.md) guide.
 
 > [!TIP]
 > Ensure that the locally used Gardener version matches the version specified by the `github.com/gardener/gardener` dependency.
 > The extension’s remote setup must run successfully against a Gardener remote setup at the version referenced by this dependency.
 
+> [!NOTE]
+> The location of the Gardener project is expected to be under the same root (e.g. `~/go/src/github.com/gardener/`). If this is not the case, the location of Gardener project should be specified in `GARDENER_REPO_ROOT` environment variable:
+> ```bash
+> export GARDENER_REPO_ROOT="<path_to_gardener_project>"
+> ```
+
 ## Setting up the Registry Cache Extension
-
-The location of the Gardener project from the Gardener setup step is expected to be under the same root (e.g. `~/go/src/github.com/gardener/`). If this is not the case, the location of Gardener project should be specified in `GARDENER_REPO_ROOT` environment variable:
-
-```bash
-export GARDENER_REPO_ROOT="<path_to_gardener_project>"
-```
-
-Then you can run:
 
 ```bash
 make remote-extension-up

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -28,6 +28,7 @@ clamp_mss_to_pmtu
 
 make -C "$REPO_ROOT/gardener" kind-up
 export KUBECONFIG=$REPO_ROOT/gardener/example/gardener-local/kind/local/kubeconfig
+export GARDENER_REPO_ROOT=$REPO_ROOT/gardener
 
 trap '{
   make -C "$REPO_ROOT/gardener" kind-down

--- a/hack/remote-extension-up.sh
+++ b/hack/remote-extension-up.sh
@@ -32,7 +32,7 @@ if kubectl get configmaps -n kube-system shoot-info --kubeconfig "$PATH_RUNTIME_
     echo "Getting registry domain from shoot"
     registry_domain=reg.$(yq -e '.data.domain' "$temp_shoot_info")
 else
-  echo "Please enter domain name for registry on the seed"
+  echo "Please enter domain name for the registry domain on the runtime cluster"
   echo "Registry domain:"
   read -er registry_domain
 fi

--- a/hack/remote-extension-up.sh
+++ b/hack/remote-extension-up.sh
@@ -7,13 +7,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-PATH_SEED_KUBECONFIG=""
+PATH_RUNTIME_KUBECONFIG=""
 
 parse_flags() {
   while test $# -gt 0; do
     case "$1" in
-    --path-seed-kubeconfig)
-      shift; PATH_SEED_KUBECONFIG="$1"
+    --path-runtime-kubeconfig)
+      shift; PATH_RUNTIME_KUBECONFIG="$1"
       ;;
     esac
     shift
@@ -28,7 +28,7 @@ cleanup-shoot-info() {
 }
 trap cleanup-shoot-info EXIT
 
-if kubectl get configmaps -n kube-system shoot-info --kubeconfig "$PATH_SEED_KUBECONFIG" -o yaml > "$temp_shoot_info"; then
+if kubectl get configmaps -n kube-system shoot-info --kubeconfig "$PATH_RUNTIME_KUBECONFIG" -o yaml > "$temp_shoot_info"; then
     echo "Getting registry domain from shoot"
     registry_domain=reg.$(yq -e '.data.domain' "$temp_shoot_info")
 else
@@ -37,13 +37,10 @@ else
   read -er registry_domain
 fi
 
-echo "Deploying registry-cache admission in garden cluster"
-skaffold run -m admission -p remote-extensions
-
 echo "Deploying registry-cache extension"
 SKAFFOLD_DEFAULT_REPO=$registry_domain \
   SKAFFOLD_CHECK_CLUSTER_NODE_PLATFORMS="false" \
   SKAFFOLD_PLATFORM="linux/amd64" \
   SKAFFOLD_DISABLE_MULTI_PLATFORM_BUILD="false" \
   SKAFFOLD_PUSH=true \
-  skaffold run -m extension
+  skaffold run -m operator -p remote --kubeconfig "$PATH_RUNTIME_KUBECONFIG"

--- a/local-setup/operator-extension/local/extension-patch.yaml
+++ b/local-setup/operator-extension/local/extension-patch.yaml
@@ -2,14 +2,7 @@ apiVersion: operator.gardener.cloud/v1alpha1
 kind: Extension
 metadata:
   name: extension-registry-cache
-  annotations:
-    security.gardener.cloud/pod-security-enforce: baseline
 spec:
-  resources:
-  - kind: Extension
-    type: registry-cache
-  - kind: Extension
-    type: registry-mirror
   deployment:
     extension:
       helm:

--- a/local-setup/operator-extension/local/kustomization.yaml
+++ b/local-setup/operator-extension/local/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../example/extension
+
+patches:
+- path: extension-patch.yaml

--- a/local-setup/operator-extension/remote/extension-patch.yaml
+++ b/local-setup/operator-extension/remote/extension-patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  name: extension-registry-cache
+spec:
+  deployment:
+    extension:
+      helm:
+        ociRepository:
+          pullSecretRef:
+            name: gardener-images
+    admission:
+      runtimeCluster:
+        helm:
+          ociRepository:
+            pullSecretRef:
+              name: gardener-images
+      virtualCluster:
+        helm:
+          ociRepository:
+            pullSecretRef:
+              name: gardener-images

--- a/local-setup/operator-extension/remote/kustomization.yaml
+++ b/local-setup/operator-extension/remote/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../local
+
+patches:
+- path: extension-patch.yaml

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -93,8 +93,9 @@ build:
   insecureRegistries:
     - registry.local.gardener.cloud:5001
 manifests:
-  rawYaml:
-    - local-setup/operator-extension-resource.yaml
+  kustomize:
+    paths:
+      - local-setup/operator-extension/local
 deploy:
   kubectl: {}
 resourceSelector:
@@ -104,3 +105,9 @@ resourceSelector:
         - .spec.deployment.extension.helm.ociRepository.ref
         - .spec.deployment.admission.runtimeCluster.helm.ociRepository.ref
         - .spec.deployment.admission.virtualCluster.helm.ociRepository.ref
+profiles:
+  - name: remote
+    manifests:
+      kustomize:
+        paths:
+          - local-setup/operator-extension/remote

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -112,10 +112,3 @@ deploy:
           image.repository: '{{.IMAGE_REPO_local_skaffold_gardener_extension_registry_cache_admission}}'
           image.tag: '{{.IMAGE_TAG_local_skaffold_gardener_extension_registry_cache_admission}}@{{.IMAGE_DIGEST_local_skaffold_gardener_extension_registry_cache_admission}}'
         wait: true
-profiles:
-  - name: remote-extensions
-    patches:
-      - op: add
-        path: /deploy/helm/releases/1/setValues
-        value:
-          vpa.enabled: false


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adapt the `remote-extension-up` and `remote-extension-down` make targets to use the [Deploying Gardener Remotely](https://github.com/gardener/gardener/blob/v1.140.0/docs/deployment/getting_started_remotely.md) remote setup. 

**Which issue(s) this PR fixes**:
Fixes #555 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The registry-cache extension does now support the [Deploying Gardener Remotely](https://github.com/gardener/gardener/blob/v1.140.0/docs/deployment/getting_started_remotely.md) development setup.
```
