### PR TITLE
Clean up the mitigation for corrupted `scheduler-state.json` file

### DIFF
--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -272,7 +272,6 @@ func (r *registryCaches) registryCacheObjects(ctx context.Context, cache *regist
 		registryCacheVolumeName  = "cache-volume"
 		registryConfigVolumeName = "config-volume"
 		registryCertsVolumeName  = "certs-volume"
-		repositoryMountPath      = "/var/lib/registry"
 	)
 
 	var (
@@ -374,32 +373,6 @@ func (r *registryCaches) registryCacheObjects(ctx context.Context, cache *regist
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 							},
-							// Mitigation for https://github.com/distribution/distribution/issues/4478:
-							// The registry image entrypoint (https://github.com/distribution/distribution-library-image/blob/be4eca0a5f3af34a026d1e9294d63f3464c06131/Dockerfile#L31)
-							// is extended with a mitigation logic for https://github.com/distribution/distribution/issues/4478.
-							// Keep in sync the registry image entrypoint with the below invocation when updating the registry image version.
-							Command: []string{"/bin/sh", "-c", `REPO_ROOT=` + repositoryMountPath + `
-SCHEDULER_STATE_FILE="${REPO_ROOT}/scheduler-state.json"
-
-if [ -f "${SCHEDULER_STATE_FILE}" ]; then
-    if [ -s "${SCHEDULER_STATE_FILE}" ]; then
-        echo "The scheduler-state.json file exists and it is not empty. Won't clean up anything..."
-    else
-        echo "Detected a corrupted scheduler-state.json file"
-
-        echo "Cleaning up the scheduler-state.json file"
-        rm -f "${SCHEDULER_STATE_FILE}"
-
-        echo "Cleaning up the docker directory"
-        rm -rf "${REPO_ROOT}/docker"
-    fi
-else
-    echo "The scheduler-state.json file is not created yet. Won't clean up anything..."
-fi
-
-echo "Starting..."
-source /entrypoint.sh /etc/distribution/config.yml
-`},
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: constants.RegistryCacheServerPort,
@@ -447,7 +420,7 @@ source /entrypoint.sh /etc/distribution/config.yml
 								{
 									Name:      registryCacheVolumeName,
 									ReadOnly:  false,
-									MountPath: repositoryMountPath,
+									MountPath: "/var/lib/registry",
 								},
 								{
 									Name:      registryConfigVolumeName,

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -331,28 +331,6 @@ proxy:
 												corev1.ResourceMemory: resource.MustParse("50Mi"),
 											},
 										},
-										Command: []string{"/bin/sh", "-c", `REPO_ROOT=/var/lib/registry
-SCHEDULER_STATE_FILE="${REPO_ROOT}/scheduler-state.json"
-
-if [ -f "${SCHEDULER_STATE_FILE}" ]; then
-    if [ -s "${SCHEDULER_STATE_FILE}" ]; then
-        echo "The scheduler-state.json file exists and it is not empty. Won't clean up anything..."
-    else
-        echo "Detected a corrupted scheduler-state.json file"
-
-        echo "Cleaning up the scheduler-state.json file"
-        rm -f "${SCHEDULER_STATE_FILE}"
-
-        echo "Cleaning up the docker directory"
-        rm -rf "${REPO_ROOT}/docker"
-    fi
-else
-    echo "The scheduler-state.json file is not created yet. Won't clean up anything..."
-fi
-
-echo "Starting..."
-source /entrypoint.sh /etc/distribution/config.yml
-`},
 										Ports: []corev1.ContainerPort{
 											{
 												ContainerPort: 5000,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
The mitigation for https://github.com/distribution/distribution/issues/4478 is no longer needed with registry 3.1.0 (https://github.com/gardener/gardener-extension-registry-cache/pull/564) as it was fixed with [Fix: resolve issue #4478 by using a temporary file for non-append writes](https://github.com/distribution/distribution/pull/4624).


**Which issue(s) this PR fixes**:
Part of #558

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
