### PR TITLE
Clean up the `resources.gardener.cloud/delete-on-invalid-update` annotation from the registry cache StatefulSets

### DIFF
--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -335,9 +335,6 @@ func (r *registryCaches) registryCacheObjects(ctx context.Context, cache *regist
 			Name:      name,
 			Namespace: metav1.NamespaceSystem,
 			Labels:    registryutils.GetLabels(name, upstreamLabel),
-			// StatefulSets need to be recreated due to the removal of the `spec.serviceName` field and the addition of the `spec.revisionHistoryLimit` field.
-			// TODO(dimitar-kostadinov): Remove the `DeleteOnInvalidUpdate` annotation in the v0.21.0 release.
-			Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -288,8 +288,6 @@ proxy:
 							"app":           name,
 							"upstream-host": upstream,
 						},
-						// TODO(dimitar-kostadinov): Remove the `DeleteOnInvalidUpdate` annotation in the v0.21.0 release.
-						Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
 					},
 					Spec: appsv1.StatefulSetSpec{
 						Selector: &metav1.LabelSelector{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:

Clean up the `resources.gardener.cloud/delete-on-invalid-update` annotation from the registry cache StatefulSets. The annotation was introduced with https://github.com/gardener/gardener-extension-registry-cache/pull/455.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-registry-cache/pull/455

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The migration logic introduced in `registry-cache@v0.18.0` to update immutable fields of the registry cache StatefulSet is now removed. Before updating to this version of the extension, ensure that you have not skipped minor versions when upgrading the extension and that the migration was executed successfully for all Shoot clusters using the extension. You can use the following [script](https://gist.github.com/ialidzhikov/946baa944882da780c31d9ab66addb26) to perform the check.
```
