### PR TITLE
Fix CA bundle path generation and forbid '..' in mirror host URL

### DIFF
--- a/pkg/apis/registry/validation/validation.go
+++ b/pkg/apis/registry/validation/validation.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	neturl "net/url"
 	"regexp"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -254,6 +255,9 @@ func ValidateURL(fldPath *field.Path, rawURL string, allowPath bool) field.Error
 	}
 	if !allowPath && url.Path != "" && url.Path != "/" {
 		allErrs = append(allErrs, field.Invalid(fldPath, rawURL, "url must not contain a path"))
+	}
+	if allowPath && slices.Contains(strings.Split(url.Path, "/"), "..") {
+		allErrs = append(allErrs, field.Invalid(fldPath, rawURL, "url path must not contain '..'"))
 	}
 	if url.User != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath, rawURL, "url must not contain user info"))

--- a/pkg/apis/registry/validation/validation.go
+++ b/pkg/apis/registry/validation/validation.go
@@ -256,8 +256,14 @@ func ValidateURL(fldPath *field.Path, rawURL string, allowPath bool) field.Error
 	if !allowPath && url.Path != "" && url.Path != "/" {
 		allErrs = append(allErrs, field.Invalid(fldPath, rawURL, "url must not contain a path"))
 	}
-	if allowPath && slices.Contains(strings.Split(url.Path, "/"), "..") {
-		allErrs = append(allErrs, field.Invalid(fldPath, rawURL, "url path must not contain '..'"))
+	if allowPath {
+		pathSegments := strings.Split(url.Path, "/")
+		if slices.Contains(pathSegments, "..") {
+			allErrs = append(allErrs, field.Invalid(fldPath, rawURL, "url path must not contain '..'"))
+		}
+		if slices.Contains(pathSegments, ".") {
+			allErrs = append(allErrs, field.Invalid(fldPath, rawURL, "url path must not contain '.'"))
+		}
 	}
 	if url.User != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath, rawURL, "url must not contain user info"))

--- a/pkg/apis/registry/validation/validation_test.go
+++ b/pkg/apis/registry/validation/validation_test.go
@@ -730,6 +730,9 @@ var _ = Describe("Validation", func() {
 			Entry("when query param is set", "https://example.com?foo=bar", true),
 			Entry("when user is set", "https://foo:bar@example.com", true),
 			Entry("when fragment is set", "https://example.com#fragment", true),
+			Entry("when path contains '../'", "https://example.com/foo/../bar", true),
+			Entry("when path is path traversal", "https://example.com/../../foo/bar", true),
+			Entry("when path is escaped path traversal", "https://example.com/..%2F..%2Ffoo%2Fbar", true),
 		)
 	})
 })

--- a/pkg/apis/registry/validation/validation_test.go
+++ b/pkg/apis/registry/validation/validation_test.go
@@ -733,6 +733,11 @@ var _ = Describe("Validation", func() {
 			Entry("when path contains '../'", "https://example.com/foo/../bar", true),
 			Entry("when path is path traversal", "https://example.com/../../foo/bar", true),
 			Entry("when path is escaped path traversal", "https://example.com/..%2F..%2Ffoo%2Fbar", true),
+			Entry("when path has escaped '..'", "https://example.com/%2E%2E/foo/bar", true),
+			Entry("when path has escaped dot after a dot literal", "https://example.com/foo/.%2E/bar", true),
+			Entry("when path contains './'", "https://example.com/foo/./bar", true),
+			Entry("when path starts with '.'", "https://example.com/./foo/bar", true),
+			Entry("when path has escaped '.'", "https://example.com/%2E/foo/bar", true),
 		)
 	})
 })

--- a/pkg/webhook/mirror/ensurer.go
+++ b/pkg/webhook/mirror/ensurer.go
@@ -189,18 +189,23 @@ func (e *ensurer) getProviderConfig(ctx context.Context, cluster *extensionscont
 	return mirrorConfig, nil
 }
 
+const caBundleFileNameSuffix = "-ca-bundle.pem"
+
 func caBundlePath(upstream, host string) string {
 	const baseDir = "/etc/containerd/certs.d"
 
 	sanitizedUpstream := sanitizeUpstream(upstream)
 	sanitizedHost := sanitizeHost(host)
 
-	return path.Join(baseDir, sanitizedUpstream, sanitizedHost+"-ca-bundle.pem")
+	return path.Join(baseDir, sanitizedUpstream, sanitizedHost+caBundleFileNameSuffix)
 }
 
 func sanitizeUpstream(upstream string) string {
 	return strings.ReplaceAll(upstream, ":", "-")
 }
+
+// maxFileNameLength is the Linux NAME_MAX limit (in bytes) for a single path component.
+const maxFileNameLength = 255
 
 func sanitizeHost(host string) string {
 	sanitizedHost := strings.TrimPrefix(host, "https://")
@@ -208,8 +213,10 @@ func sanitizeHost(host string) string {
 	sanitizedHost = strings.ReplaceAll(sanitizedHost, ":", "-")
 	sanitizedHost = strings.ReplaceAll(sanitizedHost, "/", "-")
 
-	const fileNameLengthLimit = 255 - len("-ca-bundle.pem")
+	const fileNameLengthLimit = maxFileNameLength - len(caBundleFileNameSuffix)
 	if len(sanitizedHost) > fileNameLengthLimit {
+		// Hash the original host (not the sanitized form) so that two hosts differing only
+		// in their scheme (http:// vs https://) still produce distinct file names
 		hash := utils.ComputeSHA256Hex([]byte(host))[:5]
 		limit := fileNameLengthLimit - len(hash) - 1
 		sanitizedHost = fmt.Sprintf("%s-%s", sanitizedHost[:limit], hash)

--- a/pkg/webhook/mirror/ensurer.go
+++ b/pkg/webhook/mirror/ensurer.go
@@ -19,6 +19,7 @@ import (
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -205,6 +206,14 @@ func sanitizeHost(host string) string {
 	sanitizedHost := strings.TrimPrefix(host, "https://")
 	sanitizedHost = strings.TrimPrefix(sanitizedHost, "http://")
 	sanitizedHost = strings.ReplaceAll(sanitizedHost, ":", "-")
+	sanitizedHost = strings.ReplaceAll(sanitizedHost, "/", "-")
+
+	const fileNameLengthLimit = 255 - len("-ca-bundle.pem")
+	if len(sanitizedHost) > fileNameLengthLimit {
+		hash := utils.ComputeSHA256Hex([]byte(host))[:5]
+		limit := fileNameLengthLimit - len(hash) - 1
+		sanitizedHost = fmt.Sprintf("%s-%s", sanitizedHost[:limit], hash)
+	}
 
 	return sanitizedHost
 }

--- a/pkg/webhook/mirror/ensurer_test.go
+++ b/pkg/webhook/mirror/ensurer_test.go
@@ -37,10 +37,7 @@ func TestRegistryMirrorWebhook(t *testing.T) {
 }
 
 var _ = Describe("Ensurer", func() {
-	const (
-		namespace    = "shoot--foo--bar"
-		caSecretName = "ca-bundle-v1"
-	)
+	const namespace = "shoot--foo--bar"
 
 	var (
 		logger = logr.Discard()
@@ -251,18 +248,7 @@ var _ = Describe("Ensurer", func() {
 					},
 				},
 			}
-			caBundleSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ref-" + caSecretName,
-					Namespace: namespace,
-				},
-				Immutable: ptr.To(true),
-				Data: map[string][]byte{
-					"bundle.crt": []byte("bar"),
-				},
-			}
 
-			Expect(fakeClient.Create(ctx, caBundleSecret)).To(Succeed())
 			Expect(fakeClient.Create(ctx, extension)).To(Succeed())
 
 			ensurer := mirror.NewEnsurer(fakeClient, decoder, logger)
@@ -364,6 +350,8 @@ var _ = Describe("Ensurer", func() {
 	})
 
 	Describe("#EnsureAdditionalFiles", func() {
+		const caSecretName = "ca-bundle-v1"
+
 		var (
 			cluster        *extensions.Cluster
 			extension      *extensionsv1alpha1.Extension

--- a/pkg/webhook/mirror/ensurer_test.go
+++ b/pkg/webhook/mirror/ensurer_test.go
@@ -7,6 +7,7 @@ package mirror_test
 import (
 	"context"
 	"encoding/base64"
+	"strings"
 	"testing"
 
 	extensionscontextwebhook "github.com/gardener/gardener/extensions/pkg/webhook/context"
@@ -36,7 +37,10 @@ func TestRegistryMirrorWebhook(t *testing.T) {
 }
 
 var _ = Describe("Ensurer", func() {
-	const namespace = "shoot--foo--bar"
+	const (
+		namespace    = "shoot--foo--bar"
+		caSecretName = "ca-bundle-v1"
+	)
 
 	var (
 		logger = logr.Discard()
@@ -226,6 +230,60 @@ var _ = Describe("Ensurer", func() {
 			Expect(criConfig.Containerd.Registries).To(ConsistOf(expectedRegistries))
 		})
 
+		It("should add additional registry config to the current containerd registry configs when host URL path is very long", func() {
+			gctx := extensionscontextwebhook.NewInternalGardenContext(cluster)
+			extension.Spec.ProviderConfig = &runtime.RawExtension{
+				Object: &v1alpha1.MirrorConfig{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: v1alpha1.SchemeGroupVersion.String(),
+						Kind:       "MirrorConfig",
+					},
+					Mirrors: []v1alpha1.MirrorConfiguration{
+						{
+							Upstream: "docker.io",
+							Hosts: []v1alpha1.MirrorHost{
+								{
+									Host:                        "https://private-mirror.internal/v2/docker/" + strings.Repeat("n", 208),
+									CABundleSecretReferenceName: ptr.To("ca-bundle"),
+								},
+							},
+						},
+					},
+				},
+			}
+			caBundleSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ref-" + caSecretName,
+					Namespace: namespace,
+				},
+				Immutable: ptr.To(true),
+				Data: map[string][]byte{
+					"bundle.crt": []byte("bar"),
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, caBundleSecret)).To(Succeed())
+			Expect(fakeClient.Create(ctx, extension)).To(Succeed())
+
+			ensurer := mirror.NewEnsurer(fakeClient, decoder, logger)
+
+			expectedRegistries := criConfig.Containerd.DeepCopy().Registries
+			expectedRegistries = append(expectedRegistries, extensionsv1alpha1.RegistryConfig{
+				Upstream: "docker.io",
+				Server:   ptr.To("https://registry-1.docker.io"),
+				Hosts: []extensionsv1alpha1.RegistryHost{
+					{
+						URL:          "https://private-mirror.internal/v2/docker/" + strings.Repeat("n", 208),
+						Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
+						CACerts:      []string{"/etc/containerd/certs.d/docker.io/private-mirror.internal-v2-docker-" + strings.Repeat("n", 201) + "-89994-ca-bundle.pem"},
+					},
+				},
+			})
+
+			Expect(ensurer.EnsureCRIConfig(ctx, gctx, &criConfig, nil)).To(Succeed())
+			Expect(criConfig.Containerd.Registries).To(ConsistOf(expectedRegistries))
+		})
+
 		It("should update existing registry config from containerd registry configs", func() {
 			gctx := extensionscontextwebhook.NewInternalGardenContext(cluster)
 
@@ -306,8 +364,6 @@ var _ = Describe("Ensurer", func() {
 	})
 
 	Describe("#EnsureAdditionalFiles", func() {
-		const caSecretName = "ca-bundle-v1"
-
 		var (
 			cluster        *extensions.Cluster
 			extension      *extensionsv1alpha1.Extension
@@ -503,6 +559,51 @@ var _ = Describe("Ensurer", func() {
 			expectedNewFiles = append(expectedNewFiles,
 				extensionsv1alpha1.File{
 					Path:        "/etc/containerd/certs.d/docker.io/private-mirror.internal-ca-bundle.pem",
+					Permissions: ptr.To[uint32](0644),
+					Content: extensionsv1alpha1.FileContent{
+						Inline: &extensionsv1alpha1.FileContentInline{
+							Encoding: "b64",
+							Data:     base64.StdEncoding.EncodeToString([]byte("bar")),
+						},
+					},
+				},
+			)
+
+			Expect(ensurer.EnsureAdditionalFiles(ctx, gctx, &newFiles, nil)).To(Succeed())
+			Expect(newFiles).To(ConsistOf(expectedNewFiles))
+		})
+
+		It("should add additional file to the current files when host URL path is very long", func() {
+			gctx := extensionscontextwebhook.NewInternalGardenContext(cluster)
+			extension.Spec.ProviderConfig = &runtime.RawExtension{
+				Object: &v1alpha1.MirrorConfig{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: v1alpha1.SchemeGroupVersion.String(),
+						Kind:       "MirrorConfig",
+					},
+					Mirrors: []v1alpha1.MirrorConfiguration{
+						{
+							Upstream: "docker.io",
+							Hosts: []v1alpha1.MirrorHost{
+								{
+									Host:                        "https://private-mirror.internal/v2/docker/" + strings.Repeat("n", 208),
+									CABundleSecretReferenceName: ptr.To("ca-bundle"),
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, caBundleSecret)).To(Succeed())
+			Expect(fakeClient.Create(ctx, extension)).To(Succeed())
+
+			ensurer := mirror.NewEnsurer(fakeClient, decoder, logger)
+			expectedNewFiles := make([]extensionsv1alpha1.File, len(newFiles))
+			copy(expectedNewFiles, newFiles)
+			expectedNewFiles = append(expectedNewFiles,
+				extensionsv1alpha1.File{
+					Path:        "/etc/containerd/certs.d/docker.io/private-mirror.internal-v2-docker-" + strings.Repeat("n", 201) + "-89994-ca-bundle.pem",
 					Permissions: ptr.To[uint32](0644),
 					Content: extensionsv1alpha1.FileContent{
 						Inline: &extensionsv1alpha1.FileContentInline{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug

**What this PR does / why we need it**:

Forbids the use of `..` in the URL path for `.mirrors.hosts[].host` field of the `registry-mirror` extension.
When the `.mirrors.hosts[].caBundleSecretReferenceName` field is defined, CA Bundle path generation is fixed by replacing `/` with `-` in the corresponding `host` URL path.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The use of `..` in the URL path for the `.mirrors.hosts[].host` field of the `registry-mirror` extension is now forbidden.
```

```bugfix user
The generation of a CA bundle path when `.mirrors.hosts[].caBundleSecretReferenceName` from the `registry-mirror` extension is set is now fixed.
```