### PR TITLE
charts/admission: Assume the virtual cluster always exists

### DIFF
--- a/charts/admission/charts/application/templates/serviceaccount.yaml
+++ b/charts/admission/charts/application/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.gardener.virtualCluster.enabled ( not .Values.gardener.virtualCluster.serviceAccount.name ) }}
+{{- if not .Values.gardener.virtualCluster.serviceAccount.name }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/admission/charts/application/values.yaml
+++ b/charts/admission/charts/application/values.yaml
@@ -1,6 +1,5 @@
 gardener:
   virtualCluster:
-    enabled: true
     serviceAccount: {}
 #     name: gardener-extension-registry-cache-admission
 #     namespace: kube-system

--- a/charts/admission/charts/runtime/templates/deployment.yaml
+++ b/charts/admission/charts/runtime/templates/deployment.yaml
@@ -21,9 +21,7 @@ spec:
       labels:
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-runtime-apiserver: allowed
-        {{- if .Values.gardener.virtualCluster.enabled }}
         networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443: allowed
-        {{- end }}
 {{ include "labels" . | indent 8 }}
     spec:
       {{- if .Values.gardener.runtimeCluster.priorityClassName }}
@@ -40,12 +38,8 @@ spec:
         args:
         - --webhook-config-server-port={{ .Values.webhookConfig.serverPort }}
         - --webhook-config-service-port={{ .Values.webhookConfig.servicePort }}
-        {{- if .Values.gardener.virtualCluster.enabled }}
         - --webhook-config-mode=url
         - --webhook-config-url={{ printf "%s.%s" (include "name" .) (.Release.Namespace) }}
-        {{- else }}
-        - --webhook-config-mode=service
-        {{- end}}
         - --webhook-config-namespace={{ .Release.Namespace }}
         {{- if .Values.gardener.virtualCluster.namespace }}
         - --webhook-config-owner-namespace={{ .Values.gardener.virtualCluster.namespace }}
@@ -61,11 +55,9 @@ spec:
         {{- end }}
         - --health-bind-address=:{{ .Values.healthPort }}
         - --leader-election-id={{ include "leaderelectionid" . }}
-        {{- if .Values.gardener.virtualCluster.enabled }}
         env:
         - name: SOURCE_CLUSTER
           value: enabled
-        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/charts/admission/charts/runtime/templates/deployment.yaml
+++ b/charts/admission/charts/runtime/templates/deployment.yaml
@@ -55,9 +55,6 @@ spec:
         {{- end }}
         - --health-bind-address=:{{ .Values.healthPort }}
         - --leader-election-id={{ include "leaderelectionid" . }}
-        env:
-        - name: SOURCE_CLUSTER
-          value: enabled
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/charts/admission/charts/runtime/values.yaml
+++ b/charts/admission/charts/runtime/values.yaml
@@ -30,7 +30,7 @@ service:
     enabled: false
 
 gardener:
-  virtualCluster:
-    enabled: true
+  virtualCluster: {}
+#   namespace: extension-extension-registry-cache
   runtimeCluster: {}
 #   priorityClassName: gardener-garden-system-400

--- a/cmd/gardener-extension-registry-cache-admission/app/app.go
+++ b/cmd/gardener-extension-registry-cache-admission/app/app.go
@@ -15,7 +15,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/rest"
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -88,11 +88,11 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 			managerOptions := mgrOpts.Completed().Options()
 
 			log.Info("Configuring source cluster option")
-			sourceClusterConfig, err := clientcmd.BuildConfigFromFlags("", "")
+			inClusterConfig, err := rest.InClusterConfig()
 			if err != nil {
-				return err
+				return fmt.Errorf("could not get in-cluster config: %w", err)
 			}
-			managerOptions.LeaderElectionConfig = sourceClusterConfig
+			managerOptions.LeaderElectionConfig = inClusterConfig
 
 			mgr, err := manager.New(restOpts.Completed().Config, managerOptions)
 			if err != nil {
@@ -103,7 +103,7 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 			registryinstall.Install(mgr.GetScheme())
 			mirrorinstall.Install(mgr.GetScheme())
 
-			sourceCluster, err := cluster.New(sourceClusterConfig, func(opts *cluster.Options) {
+			sourceCluster, err := cluster.New(inClusterConfig, func(opts *cluster.Options) {
 				opts.Logger = log
 				opts.Cache.DefaultNamespaces = map[string]cache.Config{v1beta1constants.GardenNamespace: {}}
 			})

--- a/cmd/gardener-extension-registry-cache-admission/app/app.go
+++ b/cmd/gardener-extension-registry-cache-admission/app/app.go
@@ -15,13 +15,10 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -90,29 +87,12 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 
 			managerOptions := mgrOpts.Completed().Options()
 
-			// Operators can enable the source cluster option via SOURCE_CLUSTER environment variable.
-			// In-cluster config will be used if no SOURCE_KUBECONFIG is specified.
-			//
-			// The source cluster is for instance used by Gardener's certificate controller, to maintain certificate
-			// secrets in a different cluster ('runtime-garden') than the cluster where the webhook configurations
-			// are maintained ('virtual-garden').
-			var sourceClusterConfig *rest.Config
-			if sourceClusterEnabled := os.Getenv("SOURCE_CLUSTER"); sourceClusterEnabled != "" {
-				log.Info("Configuring source cluster option")
-				var err error
-				sourceClusterConfig, err = clientcmd.BuildConfigFromFlags("", os.Getenv("SOURCE_KUBECONFIG"))
-				if err != nil {
-					return err
-				}
-				managerOptions.LeaderElectionConfig = sourceClusterConfig
-			} else {
-				// Restrict the cache for secrets to the configured namespace to avoid the need for cluster-wide list/watch permissions.
-				managerOptions.Cache = cache.Options{
-					ByObject: map[client.Object]cache.ByObject{
-						&corev1.Secret{}: {Namespaces: map[string]cache.Config{webhookOptions.Server.Completed().Namespace: {}}},
-					},
-				}
+			log.Info("Configuring source cluster option")
+			sourceClusterConfig, err := clientcmd.BuildConfigFromFlags("", "")
+			if err != nil {
+				return err
 			}
+			managerOptions.LeaderElectionConfig = sourceClusterConfig
 
 			mgr, err := manager.New(restOpts.Completed().Config, managerOptions)
 			if err != nil {
@@ -123,23 +103,20 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 			registryinstall.Install(mgr.GetScheme())
 			mirrorinstall.Install(mgr.GetScheme())
 
-			var sourceCluster cluster.Cluster
-			if sourceClusterConfig != nil {
-				sourceCluster, err = cluster.New(sourceClusterConfig, func(opts *cluster.Options) {
-					opts.Logger = log
-					opts.Cache.DefaultNamespaces = map[string]cache.Config{v1beta1constants.GardenNamespace: {}}
-				})
-				if err != nil {
-					return err
-				}
+			sourceCluster, err := cluster.New(sourceClusterConfig, func(opts *cluster.Options) {
+				opts.Logger = log
+				opts.Cache.DefaultNamespaces = map[string]cache.Config{v1beta1constants.GardenNamespace: {}}
+			})
+			if err != nil {
+				return err
+			}
 
-				if err := mgr.AddReadyzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthz(sourceCluster.GetCache())); err != nil {
-					return err
-				}
+			if err := mgr.AddReadyzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthz(sourceCluster.GetCache())); err != nil {
+				return err
+			}
 
-				if err = mgr.Add(sourceCluster); err != nil {
-					return err
-				}
+			if err = mgr.Add(sourceCluster); err != nil {
+				return err
 			}
 
 			log.Info("Setting up webhook server")


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:
Clean up `gardener.virtualCluster.enabled` setting from admission charts.

**Which issue(s) this PR fixes**:
Fixes #578 

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Deploying the registry-cache admission in a setup where the virtual cluster is NOT enabled is no longer supported. The presence of the virtual cluster is now always required. It is recommended to deploy the registry-cache extension via the gardener-operator.
```
