### PR TITLE
Do not create monitoring resources for Shoots with `.spec.purpose=testing`

### DIFF
--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -78,6 +78,8 @@ type Values struct {
 	Image string
 	// VPAEnabled marks whether VerticalPodAutoscaler is enabled for the shoot.
 	VPAEnabled bool
+	// MonitoringEnabled marks whether the shoot monitoring stack is available and monitoring resources should be deployed.
+	MonitoringEnabled bool
 	// Services are the registry cache services used for certificate generation.
 	Services []corev1.Service
 	// Caches are the registry caches to deploy.
@@ -155,8 +157,14 @@ func (r *registryCaches) Deploy(ctx context.Context) error {
 		return fmt.Errorf("failed to create or update managed resource: %w", err)
 	}
 
-	if err := r.deployMonitoringConfig(ctx); err != nil {
-		return fmt.Errorf("failed to deploy monitoring config: %w", err)
+	if r.values.MonitoringEnabled {
+		if err := r.deployMonitoringConfig(ctx); err != nil {
+			return fmt.Errorf("failed to deploy monitoring config: %w", err)
+		}
+	} else {
+		if err := r.destroyMonitoringConfig(ctx); err != nil {
+			return fmt.Errorf("failed to destroy monitoring config: %w", err)
+		}
 	}
 
 	return nil

--- a/pkg/component/registrycaches/registry_caches.go
+++ b/pkg/component/registrycaches/registry_caches.go
@@ -78,7 +78,7 @@ type Values struct {
 	Image string
 	// VPAEnabled marks whether VerticalPodAutoscaler is enabled for the shoot.
 	VPAEnabled bool
-	// MonitoringEnabled marks whether the shoot monitoring stack is available and monitoring resources should be deployed.
+	// MonitoringEnabled marks whether monitoring resources (Grafana dashboard, PrometheusRule, ScrapeConfig) should be deployed.
 	MonitoringEnabled bool
 	// Services are the registry cache services used for certificate generation.
 	Services []corev1.Service

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -72,8 +72,9 @@ var _ = Describe("RegistryCaches", func() {
 		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
 		secretsManager = fakesecretsmanager.New(c, namespace)
 		values = Values{
-			Image:      image,
-			VPAEnabled: true,
+			Image:             image,
+			VPAEnabled:        true,
+			MonitoringEnabled: true,
 			Services: []corev1.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -844,6 +845,51 @@ proxy:
 					})
 				})
 			})
+		})
+
+		It("should not deploy monitoring objects when MonitoringEnabled is false", func() {
+			values.MonitoringEnabled = false
+			registryCaches = New(c, namespace, secretsManager, values)
+
+			Expect(registryCaches.Deploy(ctx)).To(Succeed())
+
+			dashboardsConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "registry-cache-dashboards", Namespace: namespace},
+			}
+			prometheusRule := &monitoringv1.PrometheusRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "shoot-registry-cache", Namespace: namespace},
+			}
+			scrapeConfig := &monitoringv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "shoot-registry-cache", Namespace: namespace},
+			}
+
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(dashboardsConfigMap), dashboardsConfigMap)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "configmaps"}, dashboardsConfigMap.Name)))
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(prometheusRule), prometheusRule)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "prometheusrules"}, prometheusRule.Name)))
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(scrapeConfig), scrapeConfig)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "scrapeconfigs"}, scrapeConfig.Name)))
+		})
+
+		It("should delete existing monitoring objects when MonitoringEnabled is false", func() {
+			dashboardsConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "registry-cache-dashboards", Namespace: namespace},
+			}
+			prometheusRule := &monitoringv1.PrometheusRule{
+				ObjectMeta: metav1.ObjectMeta{Name: "shoot-registry-cache", Namespace: namespace},
+			}
+			scrapeConfig := &monitoringv1alpha1.ScrapeConfig{
+				ObjectMeta: metav1.ObjectMeta{Name: "shoot-registry-cache", Namespace: namespace},
+			}
+			Expect(c.Create(ctx, dashboardsConfigMap)).To(Succeed())
+			Expect(c.Create(ctx, prometheusRule)).To(Succeed())
+			Expect(c.Create(ctx, scrapeConfig)).To(Succeed())
+
+			values.MonitoringEnabled = false
+			registryCaches = New(c, namespace, secretsManager, values)
+
+			Expect(registryCaches.Deploy(ctx)).To(Succeed())
+
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(dashboardsConfigMap), dashboardsConfigMap)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "configmaps"}, dashboardsConfigMap.Name)))
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(prometheusRule), prometheusRule)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "prometheusrules"}, prometheusRule.Name)))
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(scrapeConfig), scrapeConfig)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "scrapeconfigs"}, scrapeConfig.Name)))
 		})
 
 		It("should deploy a monitoring objects", func() {

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -45,11 +45,6 @@ import (
 	. "github.com/gardener/gardener-extension-registry-cache/pkg/component/registrycaches"
 )
 
-const (
-	monitoringDashboardsConfigMapName = "registry-cache-dashboards"
-	monitoringConfigName              = "shoot-registry-cache"
-)
-
 var _ = Describe("RegistryCaches", func() {
 	const (
 		managedResourceName = "extension-registry-cache"
@@ -882,7 +877,7 @@ proxy:
 
 			dashboardsConfigMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      monitoringDashboardsConfigMapName,
+					Name:      "registry-cache-dashboards",
 					Namespace: namespace,
 				},
 			}
@@ -893,7 +888,7 @@ proxy:
 
 			prometheusRule := &monitoringv1.PrometheusRule{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      monitoringConfigName,
+					Name:      "shoot-registry-cache",
 					Namespace: namespace,
 				},
 			}
@@ -909,7 +904,7 @@ proxy:
 
 			scrapeConfig := &monitoringv1alpha1.ScrapeConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      monitoringConfigName,
+					Name:      "shoot-registry-cache",
 					Namespace: namespace,
 				},
 			}
@@ -938,9 +933,7 @@ proxy:
 
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: resourcesv1alpha1.SchemeGroupVersion.Group, Resource: "managedresources"}, managedResource.Name)))
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "secrets"}, managedResourceSecret.Name)))
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(dashboardsConfigMap), dashboardsConfigMap)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "configmaps"}, dashboardsConfigMap.Name)))
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(prometheusRule), prometheusRule)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "prometheusrules"}, prometheusRule.Name)))
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(scrapeConfig), scrapeConfig)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "scrapeconfigs"}, scrapeConfig.Name)))
+			expectMonitoringObjectsNotFound(ctx, c, dashboardsConfigMap, prometheusRule, scrapeConfig)
 		})
 	})
 
@@ -1030,17 +1023,18 @@ proxy:
 
 func monitoringObjects(namespace string) (*corev1.ConfigMap, *monitoringv1.PrometheusRule, *monitoringv1alpha1.ScrapeConfig) {
 	return &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: monitoringDashboardsConfigMapName, Namespace: namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: "registry-cache-dashboards", Namespace: namespace},
 		},
 		&monitoringv1.PrometheusRule{
-			ObjectMeta: metav1.ObjectMeta{Name: monitoringConfigName, Namespace: namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: "shoot-registry-cache", Namespace: namespace},
 		},
 		&monitoringv1alpha1.ScrapeConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: monitoringConfigName, Namespace: namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: "shoot-registry-cache", Namespace: namespace},
 		}
 }
 
 func expectMonitoringObjectsNotFound(ctx context.Context, c client.Client, dashboardsConfigMap *corev1.ConfigMap, prometheusRule *monitoringv1.PrometheusRule, scrapeConfig *monitoringv1alpha1.ScrapeConfig) {
+	GinkgoHelper()
 	Expect(c.Get(ctx, client.ObjectKeyFromObject(dashboardsConfigMap), dashboardsConfigMap)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "configmaps"}, dashboardsConfigMap.Name)))
 	Expect(c.Get(ctx, client.ObjectKeyFromObject(prometheusRule), prometheusRule)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "prometheusrules"}, prometheusRule.Name)))
 	Expect(c.Get(ctx, client.ObjectKeyFromObject(scrapeConfig), scrapeConfig)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1alpha1.SchemeGroupVersion.Group, Resource: "scrapeconfigs"}, scrapeConfig.Name)))

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -45,6 +45,11 @@ import (
 	. "github.com/gardener/gardener-extension-registry-cache/pkg/component/registrycaches"
 )
 
+const (
+	monitoringDashboardsConfigMapName = "registry-cache-dashboards"
+	monitoringConfigName              = "shoot-registry-cache"
+)
+
 var _ = Describe("RegistryCaches", func() {
 	const (
 		managedResourceName = "extension-registry-cache"
@@ -853,31 +858,13 @@ proxy:
 
 			Expect(registryCaches.Deploy(ctx)).To(Succeed())
 
-			dashboardsConfigMap := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: "registry-cache-dashboards", Namespace: namespace},
-			}
-			prometheusRule := &monitoringv1.PrometheusRule{
-				ObjectMeta: metav1.ObjectMeta{Name: "shoot-registry-cache", Namespace: namespace},
-			}
-			scrapeConfig := &monitoringv1alpha1.ScrapeConfig{
-				ObjectMeta: metav1.ObjectMeta{Name: "shoot-registry-cache", Namespace: namespace},
-			}
+			dashboardsConfigMap, prometheusRule, scrapeConfig := monitoringObjects(namespace)
 
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(dashboardsConfigMap), dashboardsConfigMap)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "configmaps"}, dashboardsConfigMap.Name)))
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(prometheusRule), prometheusRule)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "prometheusrules"}, prometheusRule.Name)))
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(scrapeConfig), scrapeConfig)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "scrapeconfigs"}, scrapeConfig.Name)))
+			expectMonitoringObjectsNotFound(c, ctx, dashboardsConfigMap, prometheusRule, scrapeConfig)
 		})
 
 		It("should delete existing monitoring objects when MonitoringEnabled is false", func() {
-			dashboardsConfigMap := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: "registry-cache-dashboards", Namespace: namespace},
-			}
-			prometheusRule := &monitoringv1.PrometheusRule{
-				ObjectMeta: metav1.ObjectMeta{Name: "shoot-registry-cache", Namespace: namespace},
-			}
-			scrapeConfig := &monitoringv1alpha1.ScrapeConfig{
-				ObjectMeta: metav1.ObjectMeta{Name: "shoot-registry-cache", Namespace: namespace},
-			}
+			dashboardsConfigMap, prometheusRule, scrapeConfig := monitoringObjects(namespace)
 			Expect(c.Create(ctx, dashboardsConfigMap)).To(Succeed())
 			Expect(c.Create(ctx, prometheusRule)).To(Succeed())
 			Expect(c.Create(ctx, scrapeConfig)).To(Succeed())
@@ -887,9 +874,7 @@ proxy:
 
 			Expect(registryCaches.Deploy(ctx)).To(Succeed())
 
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(dashboardsConfigMap), dashboardsConfigMap)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "configmaps"}, dashboardsConfigMap.Name)))
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(prometheusRule), prometheusRule)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "prometheusrules"}, prometheusRule.Name)))
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(scrapeConfig), scrapeConfig)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "scrapeconfigs"}, scrapeConfig.Name)))
+			expectMonitoringObjectsNotFound(c, ctx, dashboardsConfigMap, prometheusRule, scrapeConfig)
 		})
 
 		It("should deploy a monitoring objects", func() {
@@ -897,7 +882,7 @@ proxy:
 
 			dashboardsConfigMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "registry-cache-dashboards",
+					Name:      monitoringDashboardsConfigMapName,
 					Namespace: namespace,
 				},
 			}
@@ -908,7 +893,7 @@ proxy:
 
 			prometheusRule := &monitoringv1.PrometheusRule{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "shoot-registry-cache",
+					Name:      monitoringConfigName,
 					Namespace: namespace,
 				},
 			}
@@ -924,7 +909,7 @@ proxy:
 
 			scrapeConfig := &monitoringv1alpha1.ScrapeConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "shoot-registry-cache",
+					Name:      monitoringConfigName,
 					Namespace: namespace,
 				},
 			}
@@ -941,26 +926,7 @@ proxy:
 
 	Describe("#Destroy", func() {
 		It("should successfully destroy all resources", func() {
-			var (
-				dashboardsConfigMap = &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "registry-cache-dashboards",
-						Namespace: namespace,
-					},
-				}
-				prometheusRule = &monitoringv1.PrometheusRule{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "shoot-registry-cache",
-						Namespace: namespace,
-					},
-				}
-				scrapeConfig = &monitoringv1alpha1.ScrapeConfig{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "shoot-registry-cache",
-						Namespace: namespace,
-					},
-				}
-			)
+			dashboardsConfigMap, prometheusRule, scrapeConfig := monitoringObjects(namespace)
 
 			Expect(c.Create(ctx, managedResource)).To(Succeed())
 			Expect(c.Create(ctx, managedResourceSecret)).To(Succeed())
@@ -1061,3 +1027,21 @@ proxy:
 	})
 
 })
+
+func monitoringObjects(namespace string) (*corev1.ConfigMap, *monitoringv1.PrometheusRule, *monitoringv1alpha1.ScrapeConfig) {
+	return &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: monitoringDashboardsConfigMapName, Namespace: namespace},
+		},
+		&monitoringv1.PrometheusRule{
+			ObjectMeta: metav1.ObjectMeta{Name: monitoringConfigName, Namespace: namespace},
+		},
+		&monitoringv1alpha1.ScrapeConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: monitoringConfigName, Namespace: namespace},
+		}
+}
+
+func expectMonitoringObjectsNotFound(c client.Client, ctx context.Context, dashboardsConfigMap *corev1.ConfigMap, prometheusRule *monitoringv1.PrometheusRule, scrapeConfig *monitoringv1alpha1.ScrapeConfig) {
+	Expect(c.Get(ctx, client.ObjectKeyFromObject(dashboardsConfigMap), dashboardsConfigMap)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "configmaps"}, dashboardsConfigMap.Name)))
+	Expect(c.Get(ctx, client.ObjectKeyFromObject(prometheusRule), prometheusRule)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "prometheusrules"}, prometheusRule.Name)))
+	Expect(c.Get(ctx, client.ObjectKeyFromObject(scrapeConfig), scrapeConfig)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "scrapeconfigs"}, scrapeConfig.Name)))
+}

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -860,7 +860,7 @@ proxy:
 
 			dashboardsConfigMap, prometheusRule, scrapeConfig := monitoringObjects(namespace)
 
-			expectMonitoringObjectsNotFound(c, ctx, dashboardsConfigMap, prometheusRule, scrapeConfig)
+			expectMonitoringObjectsNotFound(ctx, c, dashboardsConfigMap, prometheusRule, scrapeConfig)
 		})
 
 		It("should delete existing monitoring objects when MonitoringEnabled is false", func() {
@@ -874,7 +874,7 @@ proxy:
 
 			Expect(registryCaches.Deploy(ctx)).To(Succeed())
 
-			expectMonitoringObjectsNotFound(c, ctx, dashboardsConfigMap, prometheusRule, scrapeConfig)
+			expectMonitoringObjectsNotFound(ctx, c, dashboardsConfigMap, prometheusRule, scrapeConfig)
 		})
 
 		It("should deploy a monitoring objects", func() {
@@ -1040,7 +1040,7 @@ func monitoringObjects(namespace string) (*corev1.ConfigMap, *monitoringv1.Prome
 		}
 }
 
-func expectMonitoringObjectsNotFound(c client.Client, ctx context.Context, dashboardsConfigMap *corev1.ConfigMap, prometheusRule *monitoringv1.PrometheusRule, scrapeConfig *monitoringv1alpha1.ScrapeConfig) {
+func expectMonitoringObjectsNotFound(ctx context.Context, c client.Client, dashboardsConfigMap *corev1.ConfigMap, prometheusRule *monitoringv1.PrometheusRule, scrapeConfig *monitoringv1alpha1.ScrapeConfig) {
 	Expect(c.Get(ctx, client.ObjectKeyFromObject(dashboardsConfigMap), dashboardsConfigMap)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "configmaps"}, dashboardsConfigMap.Name)))
 	Expect(c.Get(ctx, client.ObjectKeyFromObject(prometheusRule), prometheusRule)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "prometheusrules"}, prometheusRule.Name)))
 	Expect(c.Get(ctx, client.ObjectKeyFromObject(scrapeConfig), scrapeConfig)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "scrapeconfigs"}, scrapeConfig.Name)))

--- a/pkg/component/registrycaches/registry_caches_test.go
+++ b/pkg/component/registrycaches/registry_caches_test.go
@@ -1043,5 +1043,5 @@ func monitoringObjects(namespace string) (*corev1.ConfigMap, *monitoringv1.Prome
 func expectMonitoringObjectsNotFound(ctx context.Context, c client.Client, dashboardsConfigMap *corev1.ConfigMap, prometheusRule *monitoringv1.PrometheusRule, scrapeConfig *monitoringv1alpha1.ScrapeConfig) {
 	Expect(c.Get(ctx, client.ObjectKeyFromObject(dashboardsConfigMap), dashboardsConfigMap)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "configmaps"}, dashboardsConfigMap.Name)))
 	Expect(c.Get(ctx, client.ObjectKeyFromObject(prometheusRule), prometheusRule)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "prometheusrules"}, prometheusRule.Name)))
-	Expect(c.Get(ctx, client.ObjectKeyFromObject(scrapeConfig), scrapeConfig)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1.SchemeGroupVersion.Group, Resource: "scrapeconfigs"}, scrapeConfig.Name)))
+	Expect(c.Get(ctx, client.ObjectKeyFromObject(scrapeConfig), scrapeConfig)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: monitoringv1alpha1.SchemeGroupVersion.Group, Resource: "scrapeconfigs"}, scrapeConfig.Name)))
 }

--- a/pkg/controller/cache/actuator.go
+++ b/pkg/controller/cache/actuator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/util"
 	extensionssecretsmanager "github.com/gardener/gardener/extensions/pkg/util/secret/manager"
 	v1beta1helper "github.com/gardener/gardener/pkg/api/core/v1beta1/helper"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/component"
 	"github.com/go-logr/logr"
@@ -104,6 +105,7 @@ func (a *actuator) Reconcile(ctx context.Context, logger logr.Logger, ex *extens
 	registryCaches := registrycaches.New(a.client, namespace, secretsManager, registrycaches.Values{
 		Image:              image.String(),
 		VPAEnabled:         v1beta1helper.ShootWantsVerticalPodAutoscaler(cluster.Shoot),
+		MonitoringEnabled:  v1beta1helper.GetPurpose(cluster.Shoot) != gardencorev1beta1.ShootPurposeTesting,
 		Services:           services,
 		Caches:             registryConfig.Caches,
 		ResourceReferences: cluster.Shoot.Spec.Resources,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Skip deploying monitoring resources (Grafana dashboard, PrometheusRule, ScrapeConfig) for shoots with
`purpose=testing`, since testing shoots do not have an observability stack. If monitoring resources already exist (e.g. the shoot purpose was changed to `testing`), they are deleted during reconciliation.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#13899

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Monitoring resources (Grafana dashboard, PrometheusRule, ScrapeConfig) are no longer deployed for the registry cache extension for Shoots with `.spec.purpose=testing`.
```
