### PR TITLE
fix: use net.JoinHostPort to correctly format IPv6 endpoint URLs

### DIFF
--- a/hack/api-reference/registry.md
+++ b/hack/api-reference/registry.md
@@ -344,7 +344,7 @@ string
 </em>
 </td>
 <td>
-<p>Endpoint is the registry cache endpoint.<br />Examples: "https://10.4.246.205:5000", "http://10.4.26.127:5000"</p>
+<p>Endpoint is the registry cache endpoint.<br />Examples: "https://10.4.246.205:5000", "http://10.4.26.127:5000", "https://[2a05:d018:197f:7e06::1]:5000"</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/registry/types.go
+++ b/pkg/apis/registry/types.go
@@ -112,7 +112,7 @@ type RegistryCacheStatus struct {
 	// Upstream is the remote registry host (and optionally port).
 	Upstream string
 	// Endpoint is the registry cache endpoint.
-	// Examples: "https://10.4.246.205:5000", "http://10.4.26.127:5000"
+	// Examples: "https://10.4.246.205:5000", "http://10.4.26.127:5000", "https://[2a05:d018:197f:7e06::1]:5000"
 	Endpoint string
 	// RemoteURL is the remote registry URL.
 	RemoteURL string

--- a/pkg/apis/registry/v1alpha3/types.go
+++ b/pkg/apis/registry/v1alpha3/types.go
@@ -127,7 +127,7 @@ type RegistryCacheStatus struct {
 	// Upstream is the remote registry host (and optionally port).
 	Upstream string `json:"upstream"`
 	// Endpoint is the registry cache endpoint.
-	// Examples: "https://10.4.246.205:5000", "http://10.4.26.127:5000"
+	// Examples: "https://10.4.246.205:5000", "http://10.4.26.127:5000", "https://[2a05:d018:197f:7e06::1]:5000"
 	Endpoint string `json:"endpoint"`
 	// RemoteURL is the remote registry URL.
 	RemoteURL string `json:"remoteURL"`

--- a/pkg/controller/cache/actuator.go
+++ b/pkg/controller/cache/actuator.go
@@ -7,6 +7,7 @@ package extension
 import (
 	"context"
 	"fmt"
+	"net"
 
 	extensionsconfigv1alpha1 "github.com/gardener/gardener/extensions/pkg/apis/config/v1alpha1"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
@@ -237,7 +238,7 @@ func computeProviderStatus(services []corev1.Service, caSecretName *string) *v1a
 	for _, service := range services {
 		caches = append(caches, v1alpha3.RegistryCacheStatus{
 			Upstream:  service.Annotations[constants.UpstreamAnnotation],
-			Endpoint:  fmt.Sprintf("%s://%s:%d", service.Annotations[constants.SchemeAnnotation], service.Spec.ClusterIP, constants.RegistryCacheServerPort),
+			Endpoint:  fmt.Sprintf("%s://%s", service.Annotations[constants.SchemeAnnotation], net.JoinHostPort(service.Spec.ClusterIP, fmt.Sprintf("%d", constants.RegistryCacheServerPort))),
 			RemoteURL: service.Annotations[constants.RemoteURLAnnotation],
 		})
 	}

--- a/pkg/controller/cache/actuator_suite_test.go
+++ b/pkg/controller/cache/actuator_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package extension_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRegistryCacheActuator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Registry Cache Actuator Suite")
+}

--- a/pkg/controller/cache/actuator_test.go
+++ b/pkg/controller/cache/actuator_test.go
@@ -40,8 +40,8 @@ var _ = Describe("Actuator", func() {
 
 		It("should compute the status for multiple services with mixed IP families", func() {
 			services := []corev1.Service{
-				newService("10.4.246.205", "http", "docker.io", "https://registry-1.docker.io"),
-				newService("2a05:d018:197f:7e06::1", "https", "europe-docker.pkg.dev", "https://europe-docker.pkg.dev"),
+				serviceFor("10.4.246.205", "http", "docker.io", "https://registry-1.docker.io"),
+				serviceFor("2a05:d018:197f:7e06::1", "https", "europe-docker.pkg.dev", "https://europe-docker.pkg.dev"),
 			}
 			caSecretName := "ca-extension-registry-cache-1234"
 
@@ -70,7 +70,7 @@ var _ = Describe("Actuator", func() {
 	})
 })
 
-func newService(clusterIP, scheme, upstream, remoteURL string) corev1.Service {
+func serviceFor(clusterIP, scheme, upstream, remoteURL string) corev1.Service {
 	return corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{

--- a/pkg/controller/cache/actuator_test.go
+++ b/pkg/controller/cache/actuator_test.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package extension
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener-extension-registry-cache/pkg/apis/registry/v1alpha3"
+	"github.com/gardener/gardener-extension-registry-cache/pkg/constants"
+)
+
+var _ = Describe("Actuator", func() {
+
+	Describe("#computeProviderStatus", func() {
+		It("should return a status with empty caches when no services are passed", func() {
+			status := computeProviderStatus(nil, nil)
+
+			Expect(status).To(Equal(&v1alpha3.RegistryStatus{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: v1alpha3.SchemeGroupVersion.String(),
+					Kind:       "RegistryStatus",
+				},
+				Caches:       []v1alpha3.RegistryCacheStatus{},
+				CASecretName: nil,
+			}))
+		})
+
+		It("should set the CASecretName when provided", func() {
+			caSecretName := "ca-extension-registry-cache-1234"
+
+			status := computeProviderStatus(nil, &caSecretName)
+
+			Expect(status.CASecretName).To(Equal(new("ca-extension-registry-cache-1234")))
+		})
+
+		It("should compute the status for multiple services with mixed IP families", func() {
+			services := []corev1.Service{
+				newService("10.4.246.205", "http", "docker.io", "https://registry-1.docker.io"),
+				newService("2a05:d018:197f:7e06::1", "https", "europe-docker.pkg.dev", "https://europe-docker.pkg.dev"),
+			}
+			caSecretName := "ca-extension-registry-cache-1234"
+
+			status := computeProviderStatus(services, &caSecretName)
+
+			Expect(status).To(Equal(&v1alpha3.RegistryStatus{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: v1alpha3.SchemeGroupVersion.String(),
+					Kind:       "RegistryStatus",
+				},
+				CASecretName: new("ca-extension-registry-cache-1234"),
+				Caches: []v1alpha3.RegistryCacheStatus{
+					{
+						Upstream:  "docker.io",
+						Endpoint:  "http://10.4.246.205:5000",
+						RemoteURL: "https://registry-1.docker.io",
+					},
+					{
+						Upstream:  "europe-docker.pkg.dev",
+						Endpoint:  "https://[2a05:d018:197f:7e06::1]:5000",
+						RemoteURL: "https://europe-docker.pkg.dev",
+					},
+				},
+			}))
+		})
+	})
+})
+
+func newService(clusterIP, scheme, upstream, remoteURL string) corev1.Service {
+	return corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.UpstreamAnnotation:  upstream,
+				constants.SchemeAnnotation:    scheme,
+				constants.RemoteURLAnnotation: remoteURL,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: clusterIP,
+		},
+	}
+}


### PR DESCRIPTION
## Problem

On dual-stack shoots with IPv6 as the primary IP family (`ipFamilies: [IPv6, IPv4]`), the registry cache extension generates malformed endpoint URLs.

In `pkg/controller/cache/actuator.go`, `computeProviderStatus()` builds the endpoint URL as:

```go
Endpoint: fmt.Sprintf("%s://%s:%d", scheme, service.Spec.ClusterIP, constants.RegistryCacheServerPort),
```

When `service.Spec.ClusterIP` is an IPv6 address (e.g. `2a05:d018:197f:7e06::1`), this produces:

```
https://2a05:d018:197f:7e06::1:5000
```

This is invalid — [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2) requires IPv6 addresses in URLs to be enclosed in square brackets. The malformed URL is stored in `Extension.status.providerStatus` and later consumed verbatim by the webhook in `pkg/webhook/cache/ensurer.go` as the containerd registry mirror URL.

The result is that Gardener's admission webhook rejects every `OperatingSystemConfig` for every worker pool with:

```
parse "https://2a05:d018:197f:7e06::1:5000": invalid port ":d018:197f:7e06::1:5000" after host;
desired format: https://host[:port]
```

This blocks the shoot from waking up from hibernation.

## Solution

Use `net.JoinHostPort` which automatically wraps IPv6 addresses in `[...]` and is a no-op for IPv4 addresses. The `net` package is already used in this repository (see `pkg/secrets/config.go`).

## Testing

- IPv4 `10.4.246.205` → `https://10.4.246.205:5000` (unchanged)
- IPv6 `2a05:d018:197f:7e06::1` → `https://[2a05:d018:197f:7e06::1]:5000` (fixed)

---

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix malformed registry cache endpoint URLs when the registry cache Service in the Shoot contains an IPv6 clusterIP. IPv6 cluster IPs are now correctly wrapped in square brackets (e.g. `https://[2a05:d018:197f:7e06::1]:5000`)
```
