### PR TITLE
Use a dedicated namespace for the private registry e2e test

### DIFF
--- a/test/e2e/cache/create_enable_for_private_registry_delete.go
+++ b/test/e2e/cache/create_enable_for_private_registry_delete.go
@@ -32,7 +32,7 @@ import (
 const (
 	alpine3188Image           = "alpine:3.18.8"
 	registryImage             = "europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.1.1@sha256:1be55279f18a2fe1a74edf2664cac61c1bea305b7b4642dab412e7affdcb3e33"
-	upstreamRegistryNamespace = "registry-test"
+	upstreamRegistryNamespace = "test-registry"
 	upstreamConfigYAML        = `version: 0.1
 log:
   fields:
@@ -98,10 +98,11 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 		Expect(f.GardenClient.Client().Delete(ctx, secret)).To(Succeed())
 
 		if f.ShootFramework != nil {
-			ctx2, cancel2 := context.WithTimeout(parentCtx, 30*time.Second)
-			defer cancel2()
+			ctx, cancel = context.WithTimeout(parentCtx, 2*time.Minute)
+			defer cancel()
 			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: upstreamRegistryNamespace}}
-			_ = f.ShootFramework.ShootClient.Client().Delete(ctx2, ns)
+			Expect(client.IgnoreNotFound(f.ShootFramework.ShootClient.Client().Delete(ctx, ns))).To(Succeed())
+			Expect(f.ShootFramework.WaitUntilNamespaceIsDeleted(ctx, f.ShootFramework.ShootClient, upstreamRegistryNamespace)).To(Succeed())
 		}
 	})
 

--- a/test/e2e/cache/create_enable_for_private_registry_delete.go
+++ b/test/e2e/cache/create_enable_for_private_registry_delete.go
@@ -11,6 +11,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/utils"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	"github.com/gardener/gardener/test/framework"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -140,9 +141,9 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 		By("Delete upstream registry namespace")
 		ctx, cancel = context.WithTimeout(parentCtx, 2*time.Minute)
 		defer cancel()
-		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: upstreamRegistryNamespace}}
-		Expect(client.IgnoreNotFound(f.ShootFramework.ShootClient.Client().Delete(ctx, ns))).To(Succeed())
-		Expect(f.ShootFramework.WaitUntilNamespaceIsDeleted(ctx, f.ShootFramework.ShootClient, upstreamRegistryNamespace)).To(Succeed())
+		namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: upstreamRegistryNamespace}}
+		Expect(f.ShootFramework.ShootClient.Client().Delete(ctx, namespace)).To(Or(Succeed(), BeNotFoundError()))
+		Expect(f.WaitUntilNamespaceIsDeleted(ctx, f.ShootFramework.ShootClient, upstreamRegistryNamespace)).To(Succeed())
 
 		By("Delete Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
@@ -165,8 +166,8 @@ func addPrivateRegistrySecret(shoot *gardencorev1beta1.Shoot) {
 // deployUpstreamRegistry deploy test upstream registry and return the <host:port> to it
 func deployUpstreamRegistry(ctx context.Context, f *framework.ShootCreationFramework, password string) (upstreamHostPort string) {
 	// Create dedicated namespace for the upstream registry
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: upstreamRegistryNamespace}}
-	ExpectWithOffset(1, f.ShootFramework.ShootClient.Client().Create(ctx, ns)).To(Succeed())
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: upstreamRegistryNamespace}}
+	ExpectWithOffset(1, f.ShootFramework.ShootClient.Client().Create(ctx, namespace)).To(Succeed())
 
 	// Create htpasswd Secret
 	encryptedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)

--- a/test/e2e/cache/create_enable_for_private_registry_delete.go
+++ b/test/e2e/cache/create_enable_for_private_registry_delete.go
@@ -30,9 +30,10 @@ import (
 )
 
 const (
-	alpine3188Image    = "alpine:3.18.8"
-	registryImage      = "europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.1.1@sha256:1be55279f18a2fe1a74edf2664cac61c1bea305b7b4642dab412e7affdcb3e33"
-	upstreamConfigYAML = `version: 0.1
+	alpine3188Image           = "alpine:3.18.8"
+	registryImage             = "europe-docker.pkg.dev/gardener-project/releases/3rd/registry:3.1.1@sha256:1be55279f18a2fe1a74edf2664cac61c1bea305b7b4642dab412e7affdcb3e33"
+	upstreamRegistryNamespace = "registry-test"
+	upstreamConfigYAML        = `version: 0.1
 log:
   fields:
     service: registry
@@ -95,6 +96,13 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 		defer cancel()
 
 		Expect(f.GardenClient.Client().Delete(ctx, secret)).To(Succeed())
+
+		if f.ShootFramework != nil {
+			ctx2, cancel2 := context.WithTimeout(parentCtx, 30*time.Second)
+			defer cancel2()
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: upstreamRegistryNamespace}}
+			_ = f.ShootFramework.ShootClient.Client().Delete(ctx2, ns)
+		}
 	})
 
 	It("should create Shoot, enable extension for private registry, delete Shoot", func() {
@@ -156,6 +164,10 @@ func addPrivateRegistrySecret(shoot *gardencorev1beta1.Shoot) {
 
 // deployUpstreamRegistry deploy test upstream registry and return the <host:port> to it
 func deployUpstreamRegistry(ctx context.Context, f *framework.ShootCreationFramework, password string) (upstreamHostPort string) {
+	// Create dedicated namespace for the upstream registry
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: upstreamRegistryNamespace}}
+	ExpectWithOffset(1, f.ShootFramework.ShootClient.Client().Create(ctx, ns)).To(Succeed())
+
 	// Create htpasswd Secret
 	encryptedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -164,7 +176,7 @@ func deployUpstreamRegistry(ctx context.Context, f *framework.ShootCreationFrame
 	htpasswdSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-registry-auth",
-			Namespace: metav1.NamespaceSystem,
+			Namespace: upstreamRegistryNamespace,
 		},
 		Data: map[string][]byte{
 			"htpasswd": encryptedPassword,
@@ -176,7 +188,7 @@ func deployUpstreamRegistry(ctx context.Context, f *framework.ShootCreationFrame
 	configSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-registry-config",
-			Namespace: metav1.NamespaceSystem,
+			Namespace: upstreamRegistryNamespace,
 		},
 		Data: map[string][]byte{
 			"config.yml": []byte(upstreamConfigYAML),
@@ -188,7 +200,7 @@ func deployUpstreamRegistry(ctx context.Context, f *framework.ShootCreationFrame
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-registry",
-			Namespace: metav1.NamespaceSystem,
+			Namespace: upstreamRegistryNamespace,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
@@ -211,7 +223,7 @@ func deployUpstreamRegistry(ctx context.Context, f *framework.ShootCreationFrame
 	registry := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-registry",
-			Namespace: metav1.NamespaceSystem,
+			Namespace: upstreamRegistryNamespace,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			ServiceName: service.Name,
@@ -301,13 +313,13 @@ func deployUpstreamRegistry(ctx context.Context, f *framework.ShootCreationFrame
 		},
 	}
 	ExpectWithOffset(1, f.ShootFramework.ShootClient.Client().Create(ctx, registry)).To(Succeed())
-	ExpectWithOffset(1, f.WaitUntilStatefulSetIsRunning(ctx, "test-registry", metav1.NamespaceSystem, f.ShootFramework.ShootClient)).To(Succeed())
+	ExpectWithOffset(1, f.WaitUntilStatefulSetIsRunning(ctx, "test-registry", upstreamRegistryNamespace, f.ShootFramework.ShootClient)).To(Succeed())
 
 	// Alow traffic to test registry
 	networkPolicy := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "allow-test-registry",
-			Namespace: metav1.NamespaceSystem,
+			Namespace: upstreamRegistryNamespace,
 		},
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{MatchLabels: map[string]string{"app": "test-registry"}},

--- a/test/e2e/cache/create_enable_for_private_registry_delete.go
+++ b/test/e2e/cache/create_enable_for_private_registry_delete.go
@@ -96,14 +96,6 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 		defer cancel()
 
 		Expect(f.GardenClient.Client().Delete(ctx, secret)).To(Succeed())
-
-		if f.ShootFramework != nil {
-			ctx, cancel = context.WithTimeout(parentCtx, 2*time.Minute)
-			defer cancel()
-			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: upstreamRegistryNamespace}}
-			Expect(client.IgnoreNotFound(f.ShootFramework.ShootClient.Client().Delete(ctx, ns))).To(Succeed())
-			Expect(f.ShootFramework.WaitUntilNamespaceIsDeleted(ctx, f.ShootFramework.ShootClient, upstreamRegistryNamespace)).To(Succeed())
-		}
 	})
 
 	It("should create Shoot, enable extension for private registry, delete Shoot", func() {
@@ -144,6 +136,13 @@ var _ = Describe("Registry Cache Extension Tests", Label("cache"), func() {
 
 		By("[" + upstreamHostPort + "] Verify registry-cache works")
 		common.VerifyRegistryCache(parentCtx, f.Logger, f.ShootFramework.ShootClient, fmt.Sprintf("%s/%s", upstreamHostPort, alpine3188Image), common.AlpinePodMutateFn)
+
+		By("Delete upstream registry namespace")
+		ctx, cancel = context.WithTimeout(parentCtx, 2*time.Minute)
+		defer cancel()
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: upstreamRegistryNamespace}}
+		Expect(client.IgnoreNotFound(f.ShootFramework.ShootClient.Client().Delete(ctx, ns))).To(Succeed())
+		Expect(f.ShootFramework.WaitUntilNamespaceIsDeleted(ctx, f.ShootFramework.ShootClient, upstreamRegistryNamespace)).To(Succeed())
 
 		By("Delete Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Deploys the test upstream registry in a dedicated registry-test namespace instead of kube-system. This improves separation of concerns —
  kube-system should only contain resources managed by Gardener, not test infrastructure.

**Which issue(s) this PR fixes**:
Fixes #421

**Special notes for your reviewer**:
The one remaining metav1.NamespaceSystem reference in pushImageToUpstreamRegistry is intentional — it's the namespace for the privileged root
  pod executor that runs ctr commands on the node, which is unrelated to the upstream registry.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
